### PR TITLE
Register log module before first use

### DIFF
--- a/pal/src/log.c
+++ b/pal/src/log.c
@@ -10,7 +10,7 @@
 #include <sys/printk.h>
 #include <logging/log.h>
 #include <logging/log_ctrl.h>
-LOG_MODULE_DECLARE(sid_log, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(sid_log, LOG_LEVEL_DBG);
 
 #define MSG_LENGTH_MAX (CONFIG_SIDEWALK_LOG_MSG_LENGTH_MAX)
 #define LOG_FLUSH_SLEEP_PERIOD K_MSEC(5)

--- a/samples/hello_sidewalk/src/main.c
+++ b/samples/hello_sidewalk/src/main.c
@@ -8,7 +8,7 @@
 #include <sid_pal_log_ifc.h>
 
 #include <logging/log.h>
-LOG_MODULE_DECLARE(app, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(app, LOG_LEVEL_DBG);
 
 void main(void)
 {

--- a/tests/log/src/main.c
+++ b/tests/log/src/main.c
@@ -10,7 +10,7 @@
 #include "sid_pal_log_ifc.h"
 
 #include <logging/log.h>
-LOG_MODULE_DECLARE(test, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(log_test, LOG_LEVEL_DBG);
 
 void main(void)
 {


### PR DESCRIPTION
Register macro to create module-specific state and register the module with the logger core. Minimal log configuration works with registering only, but using log module register is a future-prof solution.