### PR TITLE
Fix remove zephyr symbol dependency

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -10,8 +10,7 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 config SIDEWALK_LOG_MSG_LENGTH_MAX
 	int "Log message max length"
-	default LOG_STRDUP_MAX_STRING if LOG_MODE_DEFERRED
-	default 128
+	default 64
 	help
 	  Maxium message length for Sidewalk PAL log in bytes.
 


### PR DESCRIPTION
Fix for error:
```
/ncs/sidewalk/samples/hello_sidewalk/build/zephyr/misc/generated/configs.c
/tmp/cczplMEf.s: Assembler messages:
/tmp/cczplMEf.s:199: Error: missing expression
[40/183] Building C object zephyr/CMakeFiles/zephyr.dir/lib/os/mpsc_pbuf.c.obj
ninja: build stopped: subcommand failed.
```

Log config was broken after zephyr upmerge