### PR TITLE
Twister issue fix after west update. Cleanup in UT.

### DIFF
--- a/pal/src/sid_mfg_storage.c
+++ b/pal/src/sid_mfg_storage.c
@@ -214,7 +214,7 @@ void sid_pal_mfg_store_init(sid_pal_mfg_store_region_t mfg_store_region)
 		nrf_mfg_store_region.app_value_to_offset = default_app_value_to_offset;
 	}
 
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	flash_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_flash_controller));
 	if (!flash_dev) {
 		LOG_ERR("Flash device is not found.");
 	}

--- a/pal/src/sid_storage.c
+++ b/pal/src/sid_storage.c
@@ -18,6 +18,8 @@
 /* Reserved space in the NVM memory. */
 #define NVS_RES_SPACE   (32U)
 
+/* Flash partition for NVS */
+#define NVS_FLASH_DEVICE FLASH_AREA_DEVICE(storage)
 /* Flash block size in bytes */
 #define NVS_SECTOR_SIZE  (DT_PROP(DT_CHOSEN(zephyr_flash), erase_block_size))
 /* Numbers of sectors */
@@ -45,7 +47,7 @@ static sid_error_t kv_storage_init(struct nvs_fs *fs)
 {
 	sid_error_t erc = SID_ERROR_NONE;
 
-	fs->flash_device = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	fs->flash_device = NVS_FLASH_DEVICE;
 	if (fs->flash_device == NULL) {
 		erc = SID_ERROR_GENERIC;
 	}

--- a/tests/unit_tests/pal_ble_adapter/CMakeLists.txt
+++ b/tests/unit_tests/pal_ble_adapter/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sidewalk_test_ble_adapter)
 
-cmock_handle(${ZEPHYR_BASE}/include/settings/settings.h)
+cmock_handle(${ZEPHYR_BASE}/include/zephyr/settings/settings.h)
 cmock_handle(${ZEPHYR_BASE}/../sidewalk/include/sid_ble_advert.h)
 cmock_handle(${ZEPHYR_BASE}/../sidewalk/include/sid_ble_connection.h)
 cmock_handle(${ZEPHYR_BASE}/../sidewalk/include/sid_ble_adapter_callbacks.h)

--- a/tests/unit_tests/pal_ble_adapter/src/main.c
+++ b/tests/unit_tests/pal_ble_adapter/src/main.c
@@ -21,10 +21,6 @@
 
 #include <stdbool.h>
 
-#define ESUCCESS (0)
-#define FAKE_SERVICE (9)
-#define TEST_DATA_CHUNK (128)
-
 DEFINE_FFF_GLOBALS;
 
 FAKE_VALUE_FUNC(int, bt_enable, bt_ready_cb_t);
@@ -56,6 +52,10 @@ FAKE_VALUE_FUNC(ssize_t, bt_gatt_attr_write_ccc, struct bt_conn *,
 	FAKE(bt_gatt_attr_read_chrc)	\
 	FAKE(bt_gatt_attr_read_ccc)	\
 	FAKE(bt_gatt_attr_write_ccc)
+
+#define ESUCCESS (0)
+#define FAKE_SERVICE (9)
+#define TEST_DATA_CHUNK (128)
 
 struct bt_conn {
 	uint8_t dummy;

--- a/tests/unit_tests/pal_crypto/CMakeLists.txt
+++ b/tests/unit_tests/pal_crypto/CMakeLists.txt
@@ -10,9 +10,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(sidewalk_test_crypto)
 
-# fff.h
-include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
-
 # add test file
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/unit_tests/pal_crypto/prj.conf
+++ b/tests/unit_tests/pal_crypto/prj.conf
@@ -4,5 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
 #
 CONFIG_UNITY=y
+CONFIG_TEST=y
+
 CONFIG_SIDEWALK_CRYPTO=y
-CONFIG_COVERAGE=y
+CONFIG_SIDEWALK_LOG=y

--- a/tests/unit_tests/pal_mfg_storage/CMakeLists.txt
+++ b/tests/unit_tests/pal_mfg_storage/CMakeLists.txt
@@ -12,7 +12,7 @@ add_definitions(-DDEV_ID_REG=0x33AABB99)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sidewalk_test_mfg_storage)
 
-cmock_handle(${ZEPHYR_BASE}/include/drivers/flash.h)
+cmock_handle(${ZEPHYR_BASE}/include/zephyr/drivers/flash.h)
 
 # add test file
 FILE(GLOB app_sources src/*.c)

--- a/tests/unit_tests/pal_storage_kv/CMakeLists.txt
+++ b/tests/unit_tests/pal_storage_kv/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sidewalk_test_storage_kv)
 
-cmock_handle(${ZEPHYR_BASE}/include/fs/nvs.h)
+cmock_handle(${ZEPHYR_BASE}/include/zephyr/fs/nvs.h)
 
 # add test file
 FILE(GLOB app_sources src/*.c)

--- a/tests/unit_tests/pal_storage_kv/src/main.c
+++ b/tests/unit_tests/pal_storage_kv/src/main.c
@@ -7,8 +7,8 @@
 #include <sid_pal_storage_kv_ifc.h>
 #include <mock_nvs.h>
 
-#define GROUP_ID_TEST_OK        0
-#define GROUP_ID_TEST_NOK       9
+#define GROUP_ID_TEST_OK        (0)
+#define GROUP_ID_TEST_NOK       (9)
 
 void setUp(void)
 {

--- a/tests/unit_tests/pal_uptime/src/main.c
+++ b/tests/unit_tests/pal_uptime/src/main.c
@@ -44,7 +44,7 @@ void test_sid_pal_uptime_get_now(void)
 
 void test_sid_pal_uptime_accuracy(void)
 {
-	/* Note: This is a oversimplified test fo dummy implementation.*/
+	/* Note: This is a oversimplified test for dummy implementation.*/
 	int16_t ppm;
 
 	ppm = sid_pal_uptime_get_xtal_ppm();

--- a/tests/unit_tests/sid_ble_adapter_callbacks/src/main.c
+++ b/tests/unit_tests/sid_ble_adapter_callbacks/src/main.c
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 #include <unity.h>
-#include <fff.h>
 
 #include <sid_ble_adapter_callbacks.h>
 
 #include <bluetooth/conn.h>
 #include <stdbool.h>
 
-#define TEST_DATA_CHUNK  16
+#define TEST_DATA_CHUNK  (16)
 
 typedef struct {
 	int call_cnt;

--- a/tests/unit_tests/sid_ble_advert/src/main.c
+++ b/tests/unit_tests/sid_ble_advert/src/main.c
@@ -12,19 +12,24 @@
 #include <bluetooth/conn.h>
 #include <errno.h>
 
-#define ESUCCESS 0
-
 DEFINE_FFF_GLOBALS;
 
 FAKE_VALUE_FUNC(int, bt_le_adv_start, const struct bt_le_adv_param *, const struct bt_data *, size_t, const struct bt_data *, size_t);
 FAKE_VALUE_FUNC(int, bt_le_adv_stop);
 FAKE_VALUE_FUNC(int, bt_le_adv_update_data, const struct bt_data *, size_t, const struct bt_data *, size_t);
 
+#define FFF_FAKES_LIST(FAKE)  \
+	FAKE(bt_le_adv_start) \
+	FAKE(bt_le_adv_stop)  \
+	FAKE(bt_le_adv_update_data)
+
+#define ESUCCESS (0)
+#define TEST_BUFFER_LEN (100)
+
 void setUp(void)
 {
-	RESET_FAKE(bt_le_adv_start);
-	RESET_FAKE(bt_le_adv_stop);
-	RESET_FAKE(bt_le_adv_update_data);
+	FFF_FAKES_LIST(RESET_FAKE);
+	FFF_RESET_HISTORY();
 }
 
 void test_sid_ble_advert_start(void)
@@ -109,7 +114,7 @@ bool advert_data_manuf_data_get(const struct bt_data *ad, size_t ad_len, uint8_t
 
 void test_sid_ble_advert_update_before_start(void)
 {
-	uint8_t test_result[100] = { 0 };
+	uint8_t test_result[TEST_BUFFER_LEN] = { 0 };
 	uint8_t test_result_size;
 	uint8_t test_data[] = "Lorem ipsum.";
 	const struct bt_data *advert_data;
@@ -138,7 +143,7 @@ void test_sid_ble_advert_update_before_start(void)
 
 void check_sid_ble_advert_update(uint8_t *data, uint8_t data_len)
 {
-	uint8_t test_result[100] = { 0 };
+	uint8_t test_result[TEST_BUFFER_LEN] = { 0 };
 	uint8_t test_result_size;
 	const struct bt_data *advert_data;
 	size_t advert_data_size;

--- a/tests/unit_tests/sid_ble_connection/src/main.c
+++ b/tests/unit_tests/sid_ble_connection/src/main.c
@@ -16,10 +16,6 @@
 #include <stdbool.h>
 #include <errno.h>
 
-#define CONNECTED (true)
-#define DISCONNECTED (false)
-#define ESUCCESS (0)
-
 DEFINE_FFF_GLOBALS;
 
 FAKE_VOID_FUNC(bt_conn_cb_register, struct bt_conn_cb *);
@@ -27,6 +23,17 @@ FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_ref, struct bt_conn *);
 FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
 FAKE_VALUE_FUNC(const bt_addr_le_t *, bt_conn_get_dst, const struct bt_conn *);
 FAKE_VALUE_FUNC(int, bt_conn_disconnect, struct bt_conn *, uint8_t);
+
+#define FFF_FAKES_LIST(FAKE)	  \
+	FAKE(bt_conn_cb_register) \
+	FAKE(bt_conn_ref)	  \
+	FAKE(bt_conn_unref)	  \
+	FAKE(bt_conn_get_dst)	  \
+	FAKE(bt_conn_disconnect)
+
+#define CONNECTED (true)
+#define DISCONNECTED (false)
+#define ESUCCESS (0)
 
 struct bt_conn {
 	uint8_t dummy;
@@ -42,11 +49,7 @@ static connection_callback_test_t conn_cb_test;
 
 void setUp(void)
 {
-	RESET_FAKE(bt_conn_cb_register);
-	RESET_FAKE(bt_conn_ref);
-	RESET_FAKE(bt_conn_unref);
-	RESET_FAKE(bt_conn_get_dst);
-	RESET_FAKE(bt_conn_disconnect);
+	FFF_FAKES_LIST(RESET_FAKE);
 	FFF_RESET_HISTORY();
 	memset(&conn_cb_test, 0x00, sizeof(conn_cb_test));
 }

--- a/tests/unit_tests/sid_ble_service/src/main.c
+++ b/tests/unit_tests/sid_ble_service/src/main.c
@@ -33,6 +33,8 @@ FAKE_VALUE_FUNC(struct bt_gatt_attr *, bt_gatt_find_by_uuid, const struct bt_gat
 	FAKE(bt_gatt_notify_cb)	    \
 	FAKE(bt_gatt_find_by_uuid)
 
+#define TEST_DATA_CHUNK (128)
+
 struct bt_conn {
 	uint8_t dummy;
 };
@@ -45,7 +47,7 @@ void setUp(void)
 
 void test_sid_ble_send_data_null_ptr(void)
 {
-	uint8_t data[128];
+	uint8_t data[TEST_DATA_CHUNK];
 
 	TEST_ASSERT_EQUAL(-ENOENT, sid_ble_send_data(NULL, data, sizeof(data)));
 }
@@ -57,7 +59,7 @@ void test_sid_ble_send_data_pass(void)
 	struct bt_conn conn;
 	sid_ble_srv_params_t params;
 	struct bt_gatt_attr attr;
-	uint8_t data[128];
+	uint8_t data[TEST_DATA_CHUNK];
 
 	__wrap_sid_ble_adapter_notification_sent_Expect();
 
@@ -83,7 +85,7 @@ void test_sid_ble_send_data_attr_fail(void)
 	struct bt_gatt_service_static srv;
 	struct bt_conn conn;
 	sid_ble_srv_params_t params;
-	uint8_t data[128];
+	uint8_t data[TEST_DATA_CHUNK];
 
 	params.conn = &conn;
 	params.service = &srv;
@@ -102,7 +104,7 @@ void test_sid_ble_send_data_wo_subscription(void)
 	struct bt_conn conn;
 	sid_ble_srv_params_t params;
 	struct bt_gatt_attr attr;
-	uint8_t data[128];
+	uint8_t data[TEST_DATA_CHUNK];
 
 	params.conn = &conn;
 	params.service = &srv;
@@ -121,7 +123,7 @@ void test_sid_ble_send_data_incorrect_data_len(void)
 	struct bt_conn conn;
 	sid_ble_srv_params_t params;
 	struct bt_gatt_attr attr;
-	uint8_t data[128];
+	uint8_t data[TEST_DATA_CHUNK];
 
 	params.conn = &conn;
 	params.service = &srv;
@@ -144,7 +146,7 @@ void test_sid_ble_send_data_fail(void)
 	sid_ble_srv_params_t params;
 	struct bt_gatt_attr attr;
 	int test_error_code = -ENOENT;
-	uint8_t data[128];
+	uint8_t data[TEST_DATA_CHUNK];
 
 	params.conn = &conn;
 	params.service = &srv;
@@ -163,7 +165,7 @@ void test_sid_ble_send_data_incorrect_arguments(void)
 	struct bt_conn conn;
 	sid_ble_srv_params_t params;
 	struct bt_gatt_attr attr;
-	uint8_t data[128];
+	uint8_t data[TEST_DATA_CHUNK];
 
 	params.conn = &conn;
 	params.service = &srv;


### PR DESCRIPTION
```
> Test commit
5a6ef9a (HEAD -> main, marcin/main) Twister issue fix after west update. Cleanup in UT.
> Build samples
INFO    - Zephyr version: v2.7.99-ncs1-4477-ga73fdfbe4d92
INFO    - JOBS: 16
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testcase list...
INFO    - 19 test scenarios (19 configurations) selected, 1 configurations discarded due to filters.
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    -  2/19 nrf52840dk_nrf52840       tests/unit_tests/pal_mfg_storage/unity.sidewalk.unit_tests.mfg_storage PASSED (build)
INFO    -  3/19 nrf52840dk_nrf52840       tests/unit_tests/pal_assert/unity.sidewalk.unit_tests.assert PASSED (build)
INFO    -  4/19 nrf52840dk_nrf52840       tests/unit_tests/pal_timer/unity.sidewalk.unit_tests.timer PASSED (build)
INFO    -  5/19 nrf52840dk_nrf52840       tests/unit_tests/pal_log/unity.sidewalk.unit_tests.log PASSED (build)
INFO    -  6/19 nrf52840dk_nrf52840       tests/unit_tests/pal_storage_kv/unity.sidewalk.unit_tests.storage_kv PASSED (build)
INFO    -  7/19 nrf52840dk_nrf52840       tests/unit_tests/sid_ble_advert/unity.sidewalk.unit_tests.ble_advertising PASSED (build)
INFO    -  8/19 nrf52840dk_nrf52840       tests/unit_tests/pal_uptime/unity.sidewalk.unit_tests.uptime PASSED (build)
INFO    -  9/19 nrf52840dk_nrf52840       tests/unit_tests/sid_ble_service/unity.sidewalk.unit_tests.sid_ble_service PASSED (build)
INFO    - 10/19 nrf52840dk_nrf52840       tests/unit_tests/sid_ble_adapter_callbacks/unity.sidewalk.unit_tests.ble_adapter_callbacks PASSED (build)
INFO    - 11/19 nrf52840dk_nrf52840       tests/unit_tests/pal_ble_adapter/unity.sidewalk.unit_tests.ble_adapter PASSED (build)
INFO    - 12/19 nrf52840dk_nrf52840       tests/manual/ble/sample.test.ble                   PASSED (build)
INFO    - 13/19 nrf52840dk_nrf52840       tests/manual/log/sample.test.log                   PASSED (build)
INFO    - 14/19 nrf52840dk_nrf52840       tests/functional/storage/unity.sidewalk.functional.storage PASSED (build)
INFO    - 15/19 nrf52840dk_nrf52840       tests/functional/time/unity.sidewalk.functional.time PASSED (build)
INFO    - 16/19 nrf52840dk_nrf52840       tests/functional/mfg_storage/unity.sidewalk.functional.mfg_storage PASSED (build)
INFO    - 17/19 nrf52840dk_nrf52840       tests/functional/crypto/unity.sidewalk.functional.crypto PASSED (build)
INFO    - 18/19 nrf52840dk_nrf52840       tests/unit_tests/sid_ble_connection/unity.sidewalk.unit_tests.ble_connection PASSED (build)
INFO    - 19/19 nrf52840dk_nrf52840       samples/hello_sidewalk/sample.basic.hello_world    PASSED (build)

INFO    - 18 of 19 test configurations passed (100.00%), 0 failed, 1 skipped with 0 warnings in 28.03 seconds
INFO    - 0 test configurations executed on platforms, 18 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister.xml...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister_report.xml...
INFO    - Run completed
> Run unit tests
Renaming output directory to /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out.1
INFO    - Zephyr version: v2.7.99-ncs1-4477-ga73fdfbe4d92
INFO    - JOBS: 8
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testcase list...
INFO    - 12 test scenarios (12 configurations) selected, 0 configurations discarded due to filters.
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    -  1/12 native_posix              pal_assert/unity.sidewalk.unit_tests.assert        PASSED (native 2.014s)
INFO    -  2/12 native_posix              pal_uptime/unity.sidewalk.unit_tests.uptime        PASSED (native 2.013s)
INFO    -  3/12 native_posix              sid_ble_adapter_callbacks/unity.sidewalk.unit_tests.ble_adapter_callbacks PASSED (native 2.021s)
INFO    -  4/12 native_posix              pal_storage_kv/unity.sidewalk.unit_tests.storage_kv PASSED (native 2.012s)
INFO    -  5/12 native_posix              pal_mfg_storage/unity.sidewalk.unit_tests.mfg_storage PASSED (native 2.013s)
INFO    -  6/12 native_posix              sid_ble_service/unity.sidewalk.unit_tests.sid_ble_service PASSED (native 2.010s)
INFO    -  7/12 native_posix              pal_crypto/unity.sidewalk.unit_tests.crypto        PASSED (native 2.027s)
INFO    -  8/12 native_posix              pal_ble_adapter/unity.sidewalk.unit_tests.ble_adapter PASSED (native 2.009s)
INFO    -  9/12 native_posix              pal_timer/unity.sidewalk.unit_tests.timer          PASSED (native 2.005s)
INFO    - 10/12 native_posix              sid_ble_advert/unity.sidewalk.unit_tests.ble_advertising PASSED (native 2.005s)
INFO    - 11/12 native_posix              pal_log/unity.sidewalk.unit_tests.log              PASSED (native 2.006s)
INFO    - 12/12 native_posix              sid_ble_connection/unity.sidewalk.unit_tests.ble_connection PASSED (native 2.005s)

INFO    - 12 of 12 test configurations passed (100.00%), 0 failed, 0 skipped with 0 warnings in 22.26 seconds
INFO    - In total 12 test cases were executed, 0 skipped on 1 out of total 451 platforms (0.22%)
INFO    - 12 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Generating coverage files...
INFO    - HTML report generated: /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/coverage/index.html
INFO    - Saving reports...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister.xml...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister_report.xml...
INFO    - Run completed
> Run nRF plaftorm functional tests
Renaming output directory to /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out.2
INFO    - Zephyr version: v2.7.99-ncs1-4477-ga73fdfbe4d92
INFO    - JOBS: 8
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testcase list...
INFO    - 4 test scenarios (4 configurations) selected, 0 configurations discarded due to filters.

Device testing on:

| Platform            |           ID | Serial device   |
|---------------------|--------------|-----------------|
| nrf52840dk_nrf52840 | 000683018813 | /dev/ttyACM0    |

INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/4 nrf52840dk_nrf52840       storage/unity.sidewalk.functional.storage          PASSED (device 11.677s)
INFO    - 2/4 nrf52840dk_nrf52840       crypto/unity.sidewalk.functional.crypto            PASSED (device 14.184s)
INFO    - 3/4 nrf52840dk_nrf52840       time/unity.sidewalk.functional.time                PASSED (device 13.253s)
INFO    - 4/4 nrf52840dk_nrf52840       mfg_storage/unity.sidewalk.functional.mfg_storage  PASSED (device 12.319s)

INFO    - 4 of 4 test configurations passed (100.00%), 0 failed, 0 skipped with 0 warnings in 64.21 seconds
INFO    - In total 4 test cases were executed, 0 skipped on 1 out of total 451 platforms (0.22%)
INFO    - 4 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board               |           ID |   Counter |
|---------------------|--------------|-----------|
| nrf52840dk_nrf52840 | 000683018813 |         4 |
INFO    - Saving reports...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister.xml...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister_report.xml...
INFO    - Run completed

```