### PR TITLE
Updated uncrustify for sidewalk.

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,0 +1,95 @@
+indent_with_tabs    = 2     # 1=indent to level only, 2=indent with tabs
+input_tab_size      = 8     # original tab size
+output_tab_size     = 8     # new tab size
+indent_columns      = output_tab_size
+indent_label        = 1     # pos: absolute col, neg: relative column
+indent_switch_case  = 0     # number
+
+#
+# inter-symbol newlines
+#
+
+nl_enum_brace       = remove    # "enum {" vs "enum \n {"
+nl_union_brace      = remove    # "union {" vs "union \n {"
+nl_struct_brace     = remove    # "struct {" vs "struct \n {"
+nl_do_brace         = remove    # "do {" vs "do \n {"
+nl_if_brace         = remove    # "if () {" vs "if () \n {"
+nl_for_brace        = remove    # "for () {" vs "for () \n {"
+nl_else_brace       = remove    # "else {" vs "else \n {"
+nl_while_brace      = remove    # "while () {" vs "while () \n {"
+nl_switch_brace     = remove    # "switch () {" vs "switch () \n {"
+nl_brace_while      = remove    # "} while" vs "} \n while" - cuddle while
+nl_brace_else       = remove    # "} \n else" vs "} else"
+nl_func_var_def_blk = 1
+nl_fcall_brace      = remove    # "list_for_each() {" vs "list_for_each()\n{"
+nl_fdef_brace       = add       # "int foo() {" vs "int foo()\n{"
+
+#
+# End of file behavior
+#
+
+nl_end_of_file      = force     # string (add/force/ignore/remove)
+nl_end_of_file_min  = 1         # The min number of newlines at end of file
+
+#
+# Source code modifications
+#
+
+mod_paren_on_return = ignore    # "return 1;" vs "return (1);"
+mod_full_brace_if   = add       # "if() { } else { }" vs "if() else"
+
+#
+# inter-character spacing options
+#
+
+sp_sizeof_paren     = remove    # "sizeof (int)" vs "sizeof(int)"
+sp_before_sparen    = force     # "if (" vs "if("
+sp_after_sparen     = force     # "if () {" vs "if (){"
+sp_inside_braces    = add       # "{ 1 }" vs "{1}"
+sp_inside_braces_struct = add   # "{ 1 }" vs "{1}"
+sp_inside_braces_enum   = add   # "{ 1 }" vs "{1}"
+sp_assign           = add
+sp_arith            = add
+sp_bool             = add
+sp_compare          = add
+sp_assign           = add
+sp_after_comma      = add
+sp_func_def_paren   = remove    # "int foo (){" vs "int foo(){"
+sp_func_call_paren  = remove    # "foo (" vs "foo("
+sp_func_proto_paren = remove    # "int foo ();" vs "int foo();"
+sp_inside_fparen    = remove    # "func( arg )" vs "func(arg)"
+sp_else_brace       = add       # ignore/add/remove/force
+sp_before_ptr_star  = add       # ignore/add/remove/force
+sp_after_ptr_star   = remove    # ignore/add/remove/force
+sp_between_ptr_star = remove    # ignore/add/remove/force
+sp_inside_paren     = remove    # remove spaces inside parens
+sp_paren_paren      = remove    # remove spaces between nested parens
+sp_inside_sparen    = remove    # remove spaces inside parens for if, while and the like
+sp_brace_else       = add       # ignore/add/remove/force
+sp_before_nl_cont   = ignore
+sp_cmt_cpp_start    = add
+sp_brace_typedef    = add       # }typedefd_name -> } typedefd_name
+
+cmt_sp_after_star_cont          = 1
+#
+# Aligning stuff
+#
+
+align_with_tabs     = FALSE     # use tabs to align
+align_on_tabstop    = TRUE      # align on tabstops
+align_enum_equ_span = 4         # '=' in enum definition
+align_struct_init_span  = 0     # align stuff in a structure init '= { }'
+align_right_cmt_span    = 3
+align_nl_cont	    = TRUE
+
+sp_pp_concat                              = ignore      # ignore/add/remove/force
+
+#
+# Blank line options
+#
+
+# The number of newlines after '}' of a multi-line function body
+nl_after_func_body                       = 2        # number
+
+# The number of newlines after '}' of a single line function body
+nl_after_func_body_one_liner             = 2        # number


### PR DESCRIPTION
This configuration add new line after '}' at the end of functions implementation.

NOTE: Change your uncrustify configuration in VSC: **`sidewalk/.uncrustify.cfg`**