### PR TITLE
Add nordic internal repository with sidewalk libraries

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -8,6 +8,8 @@ manifest:
     # nRF Connect SDK base URL.
     - name: ncs
       url-base: https://github.com/nrfconnect
+    - name: nordic-internal
+      url-base: ssh://git@bitbucket.nordicsemi.no:7999/ec
 
   projects:
     - name: nrf
@@ -15,6 +17,11 @@ manifest:
       path: nrf
       revision: main
       import: true
+    - name: sidewalklib
+      repo-path: nrf5-for-sidewalk
+      path: sidewalklib
+      revision: ncs-libs
+      remote: nordic-internal
 
   # West-related configuration for the sidewalk repository.
   self:


### PR DESCRIPTION
Can be tested on branch: https://github.com/ktaborowski/sdk-sidewalk/tree/ble_sample
Based on nrfxlib approach.
Requires git lfs and ssh access to internal bitbucket.
