### PR TITLE
Disable GATT catching

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -26,7 +26,6 @@ config SIDEWALK_ASSERT
 config SIDEWALK_BLE
 	imply BT
 	imply SETTINGS
-	imply BT_SETTINGS
 	imply BT_PERIPHERAL
 	imply BT_GATT_CLIENT
 	bool "Enable Sidewalk Bluettoth Low Energy module"


### PR DESCRIPTION
This change resolves issue with the error log <err> bt_gatt: Failed to save Database Hash (err -2) 
Currently we don't need to store any hash in database. 

Startup log:
```
*** Booting Zephyr OS build v3.0.99-ncs1-rc2  ***
[00:00:00.004,608] <inf> sid_template: Sidewalk example started!
[00:00:00.018,035] <inf> fs_nvs: 2 Sectors of 4096 bytes
[00:00:00.018,066] <inf> fs_nvs: alloc wra: 0, f88
[00:00:00.018,066] <inf> fs_nvs: data wra: 0, 60
[00:00:00.201,324] <inf> sidewalk: DR state [3]
[00:00:00.201,354] <dbg> sid_ble: ble_adapter_init: Enable BT
[00:00:00.201,507] <inf> sdc_hci_driver: SoftDevice Controller build revision: 
                                         33 78 2a 18 20 f5 61 61  a6 8b 77 60 62 83 39 2a |3x*. .aa ..w`b.9*
                                         7c f1 14 e4                                      ||...             
[00:00:00.206,390] <inf> bt_hci_core: No ID address. App must call settings_load()
[00:00:00.210,815] <inf> sid_thread: status changed: 1
[00:00:00.210,845] <inf> sid_thread: Registration Status = 0, Time Sync Status = 1 and Link Status Mask = 0
[00:00:00.210,845] <inf> sid_thread: Starting sidewalk thread ...
[00:00:01.785,003] <inf> sid_thread: From ISR, context 0x200036d0
[00:00:01.785,980] <inf> sid_thread: Sidewalk proc, status: 0
[00:00:01.938,995] <inf> sid_thread: From ISR, context 0x200036d0
[00:00:01.942,443] <inf> sidewalk: [MET] B:0 N:0
[00:00:01.942,443] <inf> sid_thread: Sidewalk proc, status: 0

```