### PR TITLE
Small log improvemnets

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -137,7 +137,7 @@ if SIDEWALK_LOG
 
 config SIDEWALK_LOG_MSG_LENGTH_MAX
 	int "Log message max length"
-	default 64
+	default 80
 	help
 	  Maxium message length for Sidewalk PAL log in bytes.
 


### PR DESCRIPTION
Eliminate log warning due to to short max message buffer.
Reduce number of common INF level log (less dropped messages for the same serial configuration)