### PR TITLE
Use commit hash or tags as west revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -15,12 +15,12 @@ manifest:
     - name: nrf
       repo-path: sdk-nrf
       path: nrf
-      revision: main
+      revision: v2.0.0
       import: true
     - name: sidewalklib
       repo-path: nrf5-for-sidewalk
       path: sidewalklib
-      revision: ncs-libs
+      revision: 27bae45bfe9672b95e09ec4dfe91f83abbd9b77b
       remote: nordic-internal
 
   # West-related configuration for the sidewalk repository.


### PR DESCRIPTION
Fix registration problem with non compatible workarounds in libraries and pal