### PR TITLE
Fix for coverity issue: CID 173369 Enum compared against 0

### DIFF
--- a/pal/src/sid_timer.c
+++ b/pal/src/sid_timer.c
@@ -148,8 +148,9 @@ sid_error_t sid_pal_timer_arm(sid_pal_timer_t *timer_storage,
 		return SID_ERROR_UNINITIALIZED;
 	}
 
-	if ((SID_PAL_TIMER_PRIO_CLASS_LOWPOWER < type) ||
-	    (SID_PAL_TIMER_PRIO_CLASS_PRECISE > type)) {
+	if (!IN_RANGE(type,
+		      SID_PAL_TIMER_PRIO_CLASS_PRECISE,
+		      SID_PAL_TIMER_PRIO_CLASS_LOWPOWER)) {
 		return SID_ERROR_PARAM_OUT_OF_RANGE;
 	}
 


### PR DESCRIPTION
```
> Test commit
70f858a (HEAD -> main, marcin/main) CID 173369 Enum compared against 0
> Generate map file
Keeping artifacts untouched
INFO    - Scanning connected hardware...
WARNING - Unsupported device (None): /dev/ttyS4 - n/a
INFO    - Detected devices:

| Platform   |           ID | Serial device   |
|------------|--------------|-----------------|
| unknown    | 000683676716 | /dev/ttyACM0    |
| unknown    | 000683740466 | /dev/ttyACM1    |
| unknown    | 000683405841 | /dev/ttyACM2    |
> Build samples
Keeping artifacts untouched
INFO    - Zephyr version: v3.0.99-ncs1
INFO    - JOBS: 16
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per test case
INFO    - Building initial testcase list...
INFO    - 2 test scenarios (2 configurations) selected, 0 configurations discarded due to filters.
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/2 nrf52840dk_nrf52840       template/sample.sidewalk.template.ble              PASSED (build)
INFO    - 2/2 nrf52840dk_nrf52840       template/sample.sidewalk.template.lora             PASSED (build)

INFO    - 2 of 2 test configurations passed (100.00%), 0 failed, 0 skipped with 0 warnings in 8.80 seconds
INFO    - 0 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister.xml...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister_report.xml...
INFO    - Run completed
> Run unit tests
Keeping artifacts untouched
INFO    - Zephyr version: v3.0.99-ncs1
INFO    - JOBS: 8
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testcase list...
INFO    - 20 test scenarios (20 configurations) selected, 0 configurations discarded due to filters.
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    -  1/20 native_posix              pal_assert/sidewalk.unit_tests.assert              PASSED (native 2.039s)
INFO    -  2/20 native_posix              pal_uptime/sidewalk.unit_tests.uptime              PASSED (native 2.126s)
INFO    -  3/20 native_posix              sid_ble_adapter_callbacks/sidewalk.unit_tests.ble_adapter_callbacks PASSED (native 2.026s)
INFO    -  4/20 native_posix              pal_mfg_storage/sidewalk.unit_tests.mfg_storage    PASSED (native 2.012s)
INFO    -  5/20 native_posix              pal_storage_kv/sidewalk.unit_tests.storage_kv      PASSED (native 2.012s)
INFO    -  6/20 native_posix              pal_temperature/sidewalk.unit_tests.temperature    PASSED (native 2.031s)
INFO    -  7/20 native_posix              sid_pal_gpio_utils/sidewalk.unit_tests.gpio_utils  PASSED (native 2.014s)
INFO    -  8/20 native_posix              pal_ble_adapter/sidewalk.unit_tests.ble_adapter    PASSED (native 2.015s)
INFO    -  9/20 native_posix              sid_ace_alloc/sidewalk.unit_tests.ace.alloc        PASSED (native 2.061s)
INFO    - 10/20 native_posix              pal_critical_region/sidewalk.unit_tests.critical_region PASSED (native 2.043s)
INFO    - 11/20 native_posix              sid_ble_service/sidewalk.unit_tests.sid_ble_service PASSED (native 2.028s)
INFO    - 12/20 native_posix              pal_timer/sidewalk.unit_tests.timer                PASSED (native 2.051s)
INFO    - 13/20 native_posix              pal_crypto/sidewalk.unit_tests.crypto              PASSED (native 2.062s)
INFO    - 14/20 native_posix              sid_pal_gpio/sidewalk.unit_tests.gpio              PASSED (native 2.044s)
INFO    - 15/20 native_posix              sid_pal_gpio_irq_handler/sidewalk.unit_tests.gpio_irq_handler PASSED (native 2.031s)
INFO    - 16/20 native_posix              sid_pal_gpio_irq/sidewalk.unit_tests.gpio_irq      PASSED (native 2.013s)
INFO    - 17/20 native_posix              pal_sw_interrupts/unity.sidewalk.unit_tests.interrupts PASSED (native 2.011s)
INFO    - 18/20 native_posix              sid_ble_advert/sidewalk.unit_tests.ble_advertising PASSED (native 2.030s)
INFO    - 19/20 native_posix              pal_log/sidewalk.unit_tests.log                    PASSED (native 2.008s)
INFO    - 20/20 native_posix              sid_ble_connection/sidewalk.unit_tests.ble_connection PASSED (native 2.008s)

INFO    - 20 of 20 test configurations passed (100.00%), 0 failed, 0 skipped with 0 warnings in 27.76 seconds
INFO    - In total 20 test cases were executed, 0 skipped on 1 out of total 451 platforms (0.22%)
INFO    - 20 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Generating coverage files...
INFO    - HTML report generated: /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/coverage/index.html
INFO    - Saving reports...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister.xml...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister_report.xml...
INFO    - Run completed
> Remove files from coverage that are not under test
> Run nRF plaftorm functional tests
Keeping artifacts untouched
INFO    - Zephyr version: v3.0.99-ncs1
INFO    - JOBS: 8
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testcase list...
INFO    - 9 test scenarios (9 configurations) selected, 0 configurations discarded due to filters.

Device testing on:

| Platform            |           ID | Serial device   |
|---------------------|--------------|-----------------|
| nrf52840dk_nrf52840 | 000683676716 | /dev/ttyACM0    |
| nrf52840dk_nrf52840 | 000683740466 | /dev/ttyACM1    |
| nrf52840dk_nrf52840 | 000683405841 | /dev/ttyACM2    |

INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/9 nrf52840dk_nrf52840       pal_delay/sidewalk.unit_tests.delay                PASSED (device 3.331s)
INFO    - 2/9 nrf52840dk_nrf52840       mfg_storage/sidewalk.functional.mfg_storage        PASSED (device 3.793s)
INFO    - 3/9 nrf52840dk_nrf52840       temperature/sample.test.temperature                PASSED (device 4.496s)
INFO    - 4/9 nrf52840dk_nrf52840       storage/sidewalk.functional.storage                PASSED (device 4.403s)
INFO    - 5/9 nrf52840dk_nrf52840       spi_bus/sample.test.spi_bus                        PASSED (device 4.762s)
INFO    - 6/9 nrf52840dk_nrf52840       time/sidewalk.functional.time                      PASSED (device 11.342s)
INFO    - 7/9 nrf52840dk_nrf52840       crypto/sidewalk.functional.crypto                  PASSED (device 13.405s)
INFO    - 8/9 nrf52840dk_nrf52840       critical_region/sidewalk.functional.critical_region PASSED (device 5.663s)
INFO    - 9/9 nrf52840dk_nrf52840       interrupts/unity.sidewalk.functional.interrupts    PASSED (device 6.024s)

INFO    - 9 of 9 test configurations passed (100.00%), 0 failed, 0 skipped with 0 warnings in 35.03 seconds
INFO    - In total 9 test cases were executed, 0 skipped on 1 out of total 451 platforms (0.22%)
INFO    - 9 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board               |           ID |   Counter |
|---------------------|--------------|-----------|
| nrf52840dk_nrf52840 | 000683676716 |         4 |
| nrf52840dk_nrf52840 | 000683740466 |         3 |
| nrf52840dk_nrf52840 | 000683405841 |         2 |
INFO    - Saving reports...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister.xml...
INFO    - Writing xunit report /home/maga/WorkingDirectory/sidewalk_ncs/sidewalk/twister-out/twister_report.xml...
INFO    - Run completed

```