### PR TITLE
gh: labeler: Fix setting labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,13 +15,15 @@
 
 "sid-tools":
   - "tools/**/*"
+  - "tools/*"
 
 "sid-libs":
   - "lib/**/*"
+  - "lib/*"
 
 "manifest":
   - "west.yml"
 
 # Add 'source' label to any change in repo EXCEPT the ones defined with ! at the beginning
 "source":
-  - any: ['**/*', '!docs/**/*', '!**/*.rst', '!tools/**/*', '!lib/**/*', '!west.yml']
+  - any: ['**/*', '!doc/**/*', '!doc/*', '!**/*.rst', '!tools/**/*', '!tools/*', '!lib/**/*', '!lib/*', '!west.yml']


### PR DESCRIPTION
Current rule label as doc-required changes only in doc subfolders. This fix will label also files changed in doc.
Similar fix was done for sid-tools and sid-libs

Signed-off-by: Tomasz Tyzenhauz <tomasz.tyzenhauz@nordicsemi.no>