### PR TITLE
gh: labeler: Fix sid-lib label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,7 +17,7 @@
   - "tools/**/*"
   - "tools/*"
 
-"sid-libs":
+"sid-lib":
   - "lib/**/*"
   - "lib/*"
 


### PR DESCRIPTION
Set sid-lib instead of sid-libs.

Signed-off-by: Tomasz Tyzenhauz <tomasz.tyzenhauz@nordicsemi.no>