### PR TITLE
KRKNWK-14520: Fix for GPIO_IRQ sanitizer checks error

### DIFF
--- a/pal/src/sid_gpio_irq.c
+++ b/pal/src/sid_gpio_irq.c
@@ -47,14 +47,15 @@ int sid_gpio_irq_configure(uint32_t gpio_number, gpio_flags_t irq_flags)
 	int erc = 0;
 	gpio_port_pin_t port_pin;
 	uint8_t port_number = GPIO_NUM_TO_GPIO_PORT(gpio_number);
-	struct gpio_callback *clbk = &gpio_cb[port_number];
-	bool is_initialized = ((0 != clbk->pin_mask) ? true : false);
 
 	erc = sid_gpio_utils_port_pin_get(gpio_number, &port_pin);
 	if (erc) {
 		LOG_ERR("Port pin get error %d", erc);
 		return erc;
 	}
+
+	struct gpio_callback *clbk = &gpio_cb[port_number];
+	bool is_initialized = ((0 != clbk->pin_mask) ? true : false);
 
 	WRITE_BIT(clbk->pin_mask, port_pin.pin, (GPIO_INT_DISABLE != (irq_flags & GPIO_INT_DISABLE)));
 

--- a/tests/unit_tests/sid_pal_gpio_irq/src/main.c
+++ b/tests/unit_tests/sid_pal_gpio_irq/src/main.c
@@ -42,39 +42,48 @@ static int port_pin_get_cb(uint32_t gpio_number, gpio_port_pin_t *port_pin, int 
 	return E_OK;
 }
 
+static void sid_gpio_utils_port_pin_get_test_setup(gpio_port_pin_t *port_pin)
+{
+	__wrap_sid_gpio_utils_port_pin_get_ExpectAndReturn(port_pin->pin, 0, E_OK);
+	__wrap_sid_gpio_utils_port_pin_get_IgnoreArg_gpio_number();
+	__wrap_sid_gpio_utils_port_pin_get_IgnoreArg_port_pin();
+	__wrap_sid_gpio_utils_port_pin_get_ReturnThruPtr_port_pin(port_pin);
+}
+
 void test_sid_gpio_irq_configure_fail(void)
 {
-	TEST_IGNORE_MESSAGE("Address sanitizer detected an error in this module disable it temporarily");
 	gpio_flags_t test_flag = GPIO_INT_DISABLE;
+	gpio_port_pin_t port_pin = { .pin = GPIO_NUMBER_1 };
 
 	__wrap_sid_gpio_utils_port_pin_get_IgnoreAndReturn(-ENOTSUP);
 	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_configure(INVALID_GPIO, 0));
 
-	__wrap_sid_gpio_utils_port_pin_get_IgnoreAndReturn(E_OK);
+	sid_gpio_utils_port_pin_get_test_setup(&port_pin);
 	__wrap_gpio_pin_interrupt_configure_IgnoreAndReturn(-ENOTSUP);
-	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_configure(GPIO_NUMBER_1, test_flag));
+	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_configure(port_pin.pin, test_flag));
 }
 
 void test_sid_gpio_irq_configure_add_cb_fail(void)
 {
-	TEST_IGNORE_MESSAGE("Address sanitizer detected an error in this module disable it temporarily");
+	gpio_port_pin_t port_pin = { .pin = GPIO_NUMBER_1 };
 	gpio_flags_t test_flag = GPIO_INT_ENABLE;
 
-	__wrap_sid_gpio_utils_port_pin_get_IgnoreAndReturn(E_OK);
+	sid_gpio_utils_port_pin_get_test_setup(&port_pin);
 	__wrap_gpio_pin_interrupt_configure_IgnoreAndReturn(-ENOTSUP);
 
 	__wrap_gpio_init_callback_ExpectAnyArgs();
 	__wrap_gpio_add_callback_IgnoreAndReturn(-ENOTSUP);
-	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_configure(GPIO_NUMBER_1, test_flag));
+	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_configure(port_pin.pin, test_flag));
 
+	port_pin.pin = GPIO_NUMBER_9;
+	sid_gpio_utils_port_pin_get_test_setup(&port_pin);
 	__wrap_gpio_init_callback_ExpectAnyArgs();
 	__wrap_gpio_add_callback_IgnoreAndReturn(-ENOTSUP);
-	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_configure(GPIO_NUMBER_9, test_flag));
+	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_configure(port_pin.pin, test_flag));
 }
 
 void test_sid_gpio_irq_configure_remove_cb_fail(void)
 {
-	TEST_IGNORE_MESSAGE("Address sanitizer detected an error in this module disable it temporarily");
 	gpio_flags_t test_flag = GPIO_INT_ENABLE;
 
 	__wrap_gpio_pin_interrupt_configure_IgnoreAndReturn(E_OK);
@@ -140,7 +149,6 @@ void test_sid_gpio_irq_configure_add_remove_pass(void)
 
 void test_sid_gpio_irq_set_fail(void)
 {
-	TEST_IGNORE_MESSAGE("Address sanitizer detected an error in this module disable it temporarily");
 	__wrap_sid_gpio_utils_port_pin_get_IgnoreAndReturn(-ENOTSUP);
 	TEST_ASSERT_EQUAL(-ENOTSUP, sid_gpio_irq_set(test_pin, false));
 


### PR DESCRIPTION
Restored GPIO_IRQ UTs which was marked as ignored. 
Added pin configuration in the UT to satisfy sanitizer.
Change the order in which variables are set (after first guard).

Signed-off-by: Marcin Gasiorek <marcin.gasiorek@nordicsemi.no>