### PR TITLE
build: fix compilation warning

### DIFF
--- a/pal/include/sid_ble_ama_service.h
+++ b/pal/include/sid_ble_ama_service.h
@@ -14,14 +14,18 @@
 #include <sid_ble_uuid.h>
 
 /* AMA_SERVICE */
-#define AMA_SID_BT_UUID_SERVICE             BT_UUID_DECLARE_16(AMA_SERVICE_UUID_VAL)
-#define AMA_SID_BT_CHARACTERISTIC_WRITE     BT_UUID_DECLARE_128(AMA_CHARACTERISTIC_UUID_VAL_WRITE)
-#define AMA_SID_BT_CHARACTERISTIC_NOTIFY    BT_UUID_DECLARE_128(AMA_CHARACTERISTIC_UUID_VAL_NOTIFY)
+extern struct bt_uuid_16 AMA_SID_BT_UUID_SERVICE_val;
+extern struct bt_uuid_128 AMA_SID_BT_CHARACTERISTIC_WRITE_val;
+extern struct bt_uuid_128 AMA_SID_BT_CHARACTERISTIC_NOTIFY_val;
+
+#define AMA_SID_BT_UUID_SERVICE             (struct bt_uuid *)&AMA_SID_BT_UUID_SERVICE_val
+#define AMA_SID_BT_CHARACTERISTIC_WRITE     (struct bt_uuid *)&AMA_SID_BT_CHARACTERISTIC_WRITE_val
+#define AMA_SID_BT_CHARACTERISTIC_NOTIFY    (struct bt_uuid *)&AMA_SID_BT_CHARACTERISTIC_NOTIFY_val
 
 /**
  * @brief Get the Amazon service object.
- * 
- * @return struct bt_gatt_service_static* 
+ *
+ * @return struct bt_gatt_service_static*
  */
 const struct bt_gatt_service_static *sid_ble_get_ama_service(void);
 

--- a/pal/src/sid_ble_ama_service.c
+++ b/pal/src/sid_ble_ama_service.c
@@ -17,6 +17,10 @@
 
 LOG_MODULE_REGISTER(sid_ble_ama_srv, CONFIG_SIDEWALK_LOG_LEVEL);
 
+struct bt_uuid_16 AMA_SID_BT_UUID_SERVICE_val = BT_UUID_INIT_16(AMA_SERVICE_UUID_VAL);
+struct bt_uuid_128 AMA_SID_BT_CHARACTERISTIC_WRITE_val = BT_UUID_INIT_128(AMA_CHARACTERISTIC_UUID_VAL_WRITE);
+struct bt_uuid_128 AMA_SID_BT_CHARACTERISTIC_NOTIFY_val = BT_UUID_INIT_128(AMA_CHARACTERISTIC_UUID_VAL_NOTIFY);
+
 static void ama_srv_notif_changed(const struct bt_gatt_attr *attr,
 				  uint16_t value);
 static ssize_t ama_srv_on_write(struct bt_conn *conn,


### PR DESCRIPTION
First issue was with asigning temporary value to a pointer, and compiler could not guarantee
that the value under pointer will be valid.

The second issue originates in zephyr.
Upstream zephyr already fixed this issue - check PR https://github.com/zephyrproject-rtos/zephyr/pull/49704

Both issues originates from new toolchain, (0.15.1) with new gcc

Signed-off-by: Robert Gałat <robert.galat@nordicsemi.no>