### PR TITLE
bt: disable unused gatt client

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -44,7 +44,6 @@ config SIDEWALK_BLE
 	imply BT
 	imply SETTINGS
 	imply BT_PERIPHERAL
-	imply BT_GATT_CLIENT
 
 if SIDEWALK_BLE
 


### PR DESCRIPTION
smoke test passes: send/receive and registration (ffn) on ble only sample variant