### PR TITLE
pal: no error returned on ble adapter init if already initialized

### DIFF
--- a/pal/src/sid_ble_adapter.c
+++ b/pal/src/sid_ble_adapter.c
@@ -70,7 +70,12 @@ static sid_error_t ble_adapter_init(const sid_ble_config_t *cfg)
 
 	int err_code;
 	err_code = bt_enable(NULL);
-	if (err_code) {
+	switch (err_code) {
+	case -EALREADY:
+		LOG_INF("BT already initialized");
+	case 0:
+		break;
+	default:
 		LOG_ERR("BT init failed (err %d)", err_code);
 		return SID_ERROR_GENERIC;
 	}


### PR DESCRIPTION
before
[00:00:02.193,756] <inf> sid_template: Pressed button 3
[00:00:02.193,878] <inf> sid_thread: Start Sidewalk link_mask:4
[00:00:02.194,244] <inf> sid_thread: status changed: not ready
[00:00:02.194,274] <inf> sid_thread: Device Unregistered, Time Sync Fail, Link status Down
[00:00:02.194,335] <err> sid_ble: BT disable failed (err -134)
[00:00:02.633,239] <err> sid_ble: BT init failed (err -120)
[00:00:02.633,270] **<err> sid_template: Assert in sid_ble_network_control_ifc.c:972**



after
00:00:08.296,691] <inf> sid_template: Pressed button 3
[00:00:08.296,813] <inf> sid_thread: Start Sidewalk link_mask:4
[00:00:08.297,180] <inf> sid_thread: status changed: not ready
[00:00:08.297,210] <inf> sid_thread: Device Unregistered, Time Sync Fail, Link status Down
[00:00:08.297,271] <err> sid_ble: BT disable failed (err -134)
[00:00:08.731,262] **<inf> sid_ble: BT already initialized**
[00:00:08.733,581] <inf> sid_thread: status changed: not ready
[00:00:08.733,612] <inf> sid_thread: Device Unregistered, Time Sync Fail, Link status Down
[00:00:08.733,612] <err> sid_thread: Sidewalk is not ready yet!

Fix for [KRKNWK-15930](https://projecttools.nordicsemi.no/jira/browse/KRKNWK-15930)