### PR TITLE
dfu: workaround for zephyr issue 53326

### DIFF
--- a/samples/ble_only/usb_dfu.conf
+++ b/samples/ble_only/usb_dfu.conf
@@ -5,3 +5,7 @@
 #
 
 CONFIG_SIDEWALK_DFU_SERVICE_USB=y
+
+# Workaround for issue https://github.com/zephyrproject-rtos/zephyr/issues/53326
+# Waiting for fix in upstream https://github.com/zephyrproject-rtos/zephyr/pull/53414
+CONFIG_USB_DFU_WILL_DETACH=n

--- a/samples/template/usb_dfu.conf
+++ b/samples/template/usb_dfu.conf
@@ -5,3 +5,9 @@
 #
 
 CONFIG_SIDEWALK_DFU_SERVICE_USB=y
+
+
+# Workaround for issue https://github.com/zephyrproject-rtos/zephyr/issues/53326
+# Waiting for fix in upstream https://github.com/zephyrproject-rtos/zephyr/pull/53414
+CONFIG_USB_DFU_WILL_DETACH=n
+


### PR DESCRIPTION
new config USB_DFU_WILL_DETACH has been introduced to mitigate issues with windows usb driver, but in this sokution there is a path where a mutex is called from ISR.
Disabling this config prevents the issue from reporducing

The proper fix will be added to zephyr upstream
This workaround will be removed once proper fix is merged upstream

Signed-off-by: Robert Gałat <robert.galat@nordicsemi.no>