### PR TITLE
config: mark sidewalk as experimental ncs feature

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -6,6 +6,7 @@
 
 menuconfig SIDEWALK
 	bool "Enable Amazon Sidewalk [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	imply SIDEWALK_ASSERT
 	imply SIDEWALK_BLE
 	imply SIDEWALK_CRYPTO 


### PR DESCRIPTION
[KRKNWK-16134]
build message:
warning: Experimental symbol SIDEWALK is enabled