### PR TITLE
Code improvement: cast to proper types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,10 @@ endif() # CONFIG_SIDEWALK_LOG_LEVEL_OFF
 zephyr_compile_definitions_ifndef(CONFIG_SIDEWALK_ASSERT SID_PAL_ASSERT_DISABLED)
 
 zephyr_include_directories(
-  include
-  hal/include
-  pal/include
-  lib/include
+	include
+	hal/include
+	pal/include
+	lib/include
 )
 
 add_subdirectory(pal)

--- a/pal/src/sid_log.c
+++ b/pal/src/sid_log.c
@@ -82,6 +82,7 @@ bool sid_pal_log_get_log_buffer(struct sid_pal_log_buffer *const log_buffer)
 	return false;
 }
 
-sid_pal_log_severity_t sid_log_control_get_current_log_level(void){
-	return SID_PAL_LOG_LEVEL;
+sid_pal_log_severity_t sid_log_control_get_current_log_level(void)
+{
+	return (sid_pal_log_severity_t)SID_PAL_LOG_LEVEL;
 }

--- a/pal/src/sid_uptime.c
+++ b/pal/src/sid_uptime.c
@@ -30,7 +30,7 @@ sid_error_t sid_pal_uptime_now(struct sid_timespec *result)
 
 	uint64_t uptime_ns = zephyr_uptime_ns();
 	result->tv_sec = (sid_time_t)(uptime_ns / NSEC_PER_SEC);
-	result->tv_nsec = (uint32_t)(uptime_ns - (result->tv_sec * NSEC_PER_SEC));
+	result->tv_nsec = (uint32_t)(uptime_ns - ((uint64_t)result->tv_sec * NSEC_PER_SEC));
 
 	return SID_ERROR_NONE;
 }


### PR DESCRIPTION
The change in sid_uptime.c is related to unintentional integer overflow. Second change in the sid_log.c file is necessary because SID_PAL_LOG_LEVEL is taken from a cmake file, this type is incompatible and it needs to be cast.

Signed-off-by: Marcin Gasiorek <marcin.gasiorek@nordicsemi.no>