### PR TITLE
samples: Update radio wake-up delay

### DIFF
--- a/samples/common/src/sidewalk_thread.c
+++ b/samples/common/src/sidewalk_thread.c
@@ -229,7 +229,7 @@ const radio_sx126x_device_config_t radio_sx1262_cfg = {
 	},
 
 	.state_timings = {
-		.sleep_to_full_power_us = 406,
+		.sleep_to_full_power_us = 440,
 		.full_power_to_sleep_us = 0,
 		.rx_to_tx_us = 0,
 		.tx_to_rx_us = 0,
@@ -266,7 +266,7 @@ static void on_sidewalk_msg_sent(const struct sid_msg_desc *msg_desc, void *cont
 	#ifdef CONFIG_SIDEWALK_CLI
 	CLI_register_message_send();
 	#endif
-	LOG_DBG("sent message(type: %d, id: %u)", (int)msg_desc->type, msg_desc->id);
+	LOG_INF("sent message(type: %d, id: %u)", (int)msg_desc->type, msg_desc->id);
 }
 
 static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc *msg_desc, void *context)

--- a/samples/sensor_monitoring/config/app_900_config.c
+++ b/samples/sensor_monitoring/config/app_900_config.c
@@ -124,7 +124,7 @@ const radio_sx126x_device_config_t radio_sx1262_cfg = {
 	},
 
 	.state_timings = {
-		.sleep_to_full_power_us = 406,
+		.sleep_to_full_power_us = 440,
 		.full_power_to_sleep_us = 0,
 		.rx_to_tx_us = 0,
 		.tx_to_rx_us = 0,

--- a/tests/manual/sid_dut/src/sid_thread.c
+++ b/tests/manual/sid_dut/src/sid_thread.c
@@ -274,7 +274,7 @@ const radio_sx126x_device_config_t radio_sx1262_cfg = {
 	},
 
 	.state_timings = {
-		.sleep_to_full_power_us = 406,
+		.sleep_to_full_power_us = 440,
 		.full_power_to_sleep_us = 0,
 		.rx_to_tx_us = 0,
 		.tx_to_rx_us = 0,


### PR DESCRIPTION
The wake-up value is took from SPI traces and is similar to value read in NRF5 SDK.