### PR TITLE
ble: add mtu negotiation in connection handler

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -56,6 +56,7 @@ config SIDEWALK_BLE
 	imply BT
 	imply SETTINGS
 	imply BT_PERIPHERAL
+	imply BT_GATT_CLIENT
 
 if SIDEWALK_BLE
 

--- a/pal/src/sid_ble_connection.c
+++ b/pal/src/sid_ble_connection.c
@@ -34,6 +34,14 @@ static struct bt_gatt_cb gatt_callbacks = {
 	.att_mtu_updated = ble_mtu_cb
 };
 
+static struct bt_gatt_exchange_params exchange_params;
+
+static void exchange_func(struct bt_conn *conn, uint8_t err,
+			  struct bt_gatt_exchange_params *params)
+{
+	LOG_INF("Exchange MTU finished err status: %d", err);
+}
+
 /**
  * @brief The function is called when a new connection is established.
  *
@@ -58,6 +66,11 @@ static void ble_connect_cb(struct bt_conn *conn, uint8_t err)
 
 	k_mutex_lock(&bt_conn_mutex, K_FOREVER);
 	conn_params.conn = bt_conn_ref(conn);
+	exchange_params.func = exchange_func;
+	int error = bt_gatt_exchange_mtu(conn_params.conn, &exchange_params);
+	if (error) {
+		LOG_WRN("bt_gatt_exchange_mtu: %d", error);
+	}
 	sid_ble_adapter_conn_connected((const uint8_t *)conn_params.addr);
 	k_mutex_unlock(&bt_conn_mutex);
 

--- a/tests/unit_tests/pal_ble_adapter/src/main.c
+++ b/tests/unit_tests/pal_ble_adapter/src/main.c
@@ -27,6 +27,7 @@ FAKE_VALUE_FUNC(int, bt_enable, bt_ready_cb_t);
 FAKE_VALUE_FUNC(int, bt_disable);
 FAKE_VALUE_FUNC(int, bt_le_adv_start, const struct bt_le_adv_param *, const struct bt_data *, size_t,
 		const struct bt_data *, size_t);
+FAKE_VALUE_FUNC(int, bt_gatt_exchange_mtu, struct bt_conn *, struct bt_gatt_exchange_params *);
 
 FAKE_VALUE_FUNC(int, bt_le_adv_stop);
 FAKE_VOID_FUNC(bt_conn_cb_register, struct bt_conn_cb *);
@@ -48,9 +49,13 @@ FAKE_VALUE_FUNC(ssize_t, bt_gatt_attr_write_ccc, struct bt_conn *,
 
 #define FFF_FAKES_LIST(FAKE)		\
 	FAKE(bt_enable)			\
+	FAKE(bt_disable)                \
 	FAKE(bt_le_adv_start)		\
+	FAKE(bt_le_adv_stop)            \
+	FAKE(bt_gatt_exchange_mtu)      \
 	FAKE(bt_conn_cb_register)	\
 	FAKE(bt_conn_ref)		\
+	FAKE(bt_conn_unref)             \
 	FAKE(bt_conn_get_dst)		\
 	FAKE(bt_gatt_attr_read_service)	\
 	FAKE(bt_gatt_attr_read_chrc)	\

--- a/tests/unit_tests/sid_ble_connection/src/main.c
+++ b/tests/unit_tests/sid_ble_connection/src/main.c
@@ -25,6 +25,7 @@ FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_ref, struct bt_conn *);
 FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
 FAKE_VALUE_FUNC(const bt_addr_le_t *, bt_conn_get_dst, const struct bt_conn *);
 FAKE_VALUE_FUNC(int, bt_conn_disconnect, struct bt_conn *, uint8_t);
+FAKE_VALUE_FUNC(int, bt_gatt_exchange_mtu, struct bt_conn *, struct bt_gatt_exchange_params *);
 
 #define FFF_FAKES_LIST(FAKE)	  \
 	FAKE(bt_conn_cb_register) \
@@ -32,7 +33,8 @@ FAKE_VALUE_FUNC(int, bt_conn_disconnect, struct bt_conn *, uint8_t);
 	FAKE(bt_conn_ref)	  \
 	FAKE(bt_conn_unref)	  \
 	FAKE(bt_conn_get_dst)	  \
-	FAKE(bt_conn_disconnect)
+	FAKE(bt_conn_disconnect)  \
+	FAKE(bt_gatt_exchange_mtu)
 
 #define CONNECTED (true)
 #define DISCONNECTED (false)


### PR DESCRIPTION
Some applications that connect to the device initiate MTU negotiation, and some don't in case where no one initiate the mtu change, it is left at minimum value.
This causes increased number of messages, and delay in sending

[KRKNWK-16444](https://projecttools.nordicsemi.no/jira/browse/KRKNWK-16444)