### PR TITLE
git: fix the install_hooks script

### DIFF
--- a/scripts/git_hooks/install_hooks.sh
+++ b/scripts/git_hooks/install_hooks.sh
@@ -3,9 +3,7 @@
 link_hook()
 {
     hook_name=$1
-    if test -f "$ZEPHYR_BASE/../sidewalk/.git/hooks/$hook_name"; then
-        rm -rf $ZEPHYR_BASE/../sidewalk/.git/hooks/$hook_name
-    fi
+    rm -rf $ZEPHYR_BASE/../sidewalk/.git/hooks/$hook_name
 
     ln -s $ZEPHYR_BASE/../sidewalk/scripts/git_hooks/$hook_name  $ZEPHYR_BASE/../sidewalk/.git/hooks/$hook_name
     chmod +x $ZEPHYR_BASE/../sidewalk/scripts/git_hooks/$hook_name


### PR DESCRIPTION
If there already was a link to a script, that was broken, it would not be deleted, and ln could not create new one. rm -rf will not prompt an error if the file does not exist, and if it does it will be deleted