### PR TITLE
fix: Kconfig reorder in power measurement test app

### DIFF
--- a/tests/manual/power/Kconfig
+++ b/tests/manual/power/Kconfig
@@ -4,10 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
 #
 
-rsource "../../../samples/common/Kconfig.defconfig"
-
-source "Kconfig.zephyr"
-
 config STATE_NOTIFIER_HANDLER_MAX
 	default 3
 
@@ -18,3 +14,6 @@ config DELAY_BETWEN_MESSAGES
 config MESSAGES_TO_SEND
     int "number of messages to send during test"
     default 20
+
+rsource "../../../samples/common/Kconfig.defconfig"
+source "Kconfig.zephyr"

--- a/tests/manual/power/src/main.c
+++ b/tests/manual/power/src/main.c
@@ -215,7 +215,10 @@ void main(void)
 {
 	extern struct notifier_ctx global_state_notifier;
 
-	subscribe_for_state_change(&global_state_notifier, state_change_handler_power_test);
+	if(!subscribe_for_state_change(&global_state_notifier, state_change_handler_power_test))
+	{
+		__ASSERT(false, "failed to initialize the state watch, is the CONFIG_STATE_NOTIFIER_HANDLER_MAX too low ?");
+	}
 
 	if (0 != board_init()) {
 		return;

--- a/tests/manual/power_ble_only/Kconfig
+++ b/tests/manual/power_ble_only/Kconfig
@@ -4,10 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
 #
 
-rsource "../../../samples/common/Kconfig.defconfig"
-
-source "Kconfig.zephyr"
-
 config STATE_NOTIFIER_HANDLER_MAX
 	default 3
 
@@ -18,3 +14,6 @@ config DELAY_BETWEN_MESSAGES
 config MESSAGES_TO_SEND
     int "number of messages to send during test"
     default 20
+
+rsource "../../../samples/common/Kconfig.defconfig"
+source "Kconfig.zephyr"

--- a/tests/manual/power_ble_only/src/main.c
+++ b/tests/manual/power_ble_only/src/main.c
@@ -215,8 +215,10 @@ void main(void)
 {
 	extern struct notifier_ctx global_state_notifier;
 
-	subscribe_for_state_change(&global_state_notifier, state_change_handler_power_test);
-
+	if (!subscribe_for_state_change(&global_state_notifier, state_change_handler_power_test))
+	{
+		__ASSERT(false, "failed to initialize the state watch, is the CONFIG_STATE_NOTIFIER_HANDLER_MAX too low ?");
+	}
 	if (0 != board_init()) {
 		return;
 	}


### PR DESCRIPTION
always source Kconfig.zephyr at the end of Kconfig file