### PR TITLE
pal: Prevent double initialisation of storage

### DIFF
--- a/subsys/sal/sid_pal/src/sid_storage.c
+++ b/subsys/sal/sid_pal/src/sid_storage.c
@@ -63,11 +63,18 @@ static sid_error_t kv_storage_init(struct nvs_fs *fs)
 sid_error_t sid_pal_storage_kv_init()
 {
 #if defined(CONFIG_NVS)
+	static bool init_done = false;
+
+	if (init_done) {
+		return SID_ERROR_NONE;
+	}
+
 	for (int cnt = 0; cnt < SID_GROUP_ID_COUNT; cnt++) {
 		if (SID_ERROR_NONE != kv_storage_init(&fs[cnt])) {
 			return SID_ERROR_GENERIC;
 		}
 	}
+	init_done = true;
 	return SID_ERROR_NONE;
 #else
 	return SID_ERROR_NOSUPPORT;


### PR DESCRIPTION
The sid_pal_storage_kv_init() function is executed twice - one from stack and once for application init. The second initialisation is not required, so static flag added to prevent double initialisation.