### PR TITLE
fix: disable arduino_serial/uart1

### DIFF
--- a/Kconfig.dependecies
+++ b/Kconfig.dependecies
@@ -228,3 +228,6 @@ config USB_DEVICE_PRODUCT
 config USB_REQUEST_BUFFER_SIZE
 	default 8192
 endif # SIDEWALK_DFU_SERVICE_USB
+
+config UART_1_NRF_UARTE
+    default n


### PR DESCRIPTION
This peripheral is unused, but it is enabled by default This takes ownership over GPIO assigned to this peripheral, and they can not be used in applicaiton
Zephyr upstream already disables it