### PR TITLE
build: remove gitpython dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-GitPython==3.1.29
-
 -r scripts/ci/requirements.txt

--- a/scripts/generate_version_info_overlay.py
+++ b/scripts/generate_version_info_overlay.py
@@ -2,13 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-try:
-    import git
-except ImportError as e:
-    raise Exception(
-        "GitPython module not found! install packages from `sidewalk/requirements.txt`")
-    exit(-1)
-
+import subprocess
 from pathlib import Path
 import os
 import re
@@ -19,8 +13,12 @@ def subtext(text, regex, if_none):
     return if_none if exp is None else exp.group(1)
 
 
-version = git.repo.Repo(Path(os.path.normpath(
-    __file__)).parents[2] / "sidewalk").git.describe()
+git_describe_cmd = subprocess.run(["git", "describe"], cwd=Path(
+    os.path.normpath(__file__)).parents[2] / "sidewalk", capture_output=True)
+if git_describe_cmd.returncode != 0:
+    version = "unknown"
+
+version = git_describe_cmd.stdout.decode("utf-8")
 version_numbers = subtext(version, "v(\d+\.\d+\.\d+)", "0.0.0") + \
     "+" + subtext(version, "v[\d\.]+-(\d+)", "0")
 print(f"CONFIG_MCUBOOT_IMAGE_VERSION=\"{version_numbers}\"")


### PR DESCRIPTION
The python scripts are used during build process, and gitpython is not installed by default, so it could cause issues on clean setup