### PR TITLE
tests: Add missing code to send messages in test

### DIFF
--- a/tests/manual/power/src/main.c
+++ b/tests/manual/power/src/main.c
@@ -251,6 +251,10 @@ static inline void perform_power_test(void)
 			wait_for_connected();
 		}
 	#endif
+		wait_for_connected();
+		wait_for_not_sending();
+		app_event_send(BUTTON_EVENT_SEND_HELLO);
+		k_sleep(K_MSEC(CONFIG_DELAY_BETWEN_MESSAGES));
 	}
 }
 


### PR DESCRIPTION
KRKNWK-16772
During refactoring part of the test has been accidentally deleted