### PR TITLE
github: add badge with build status for main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://github.com/nrfconnect/sdk-sidewalk/actions/workflows/on_commit.yml/badge.svg?branch=main
+ :target: https://github.com/nrfconnect/sdk-sidewalk/actions/workflows/on_commit.yml
+
+
 nRF Connect SDK: sdk-sidewalk
 #############################
 


### PR DESCRIPTION
Badge has been added that show if all samples and tests build correctly on the latest commit on main branch