### PR TITLE
github: create weekly PR with NRF upmerge

### DIFF
--- a/.github/workflows/nrf_upmergePR.yml
+++ b/.github/workflows/nrf_upmergePR.yml
@@ -1,0 +1,49 @@
+name: NRF upmerge
+
+on:
+  schedule:
+    - cron: "0 1 * * 0"
+  
+  workflow_dispatch:
+
+jobs:
+  Change_NRF_revision:
+
+    name: Create PR with NRF upmerge
+    runs-on: ubuntu-latest
+    env: 
+      CI_COMMIT_AUTHOR: Continuous Integration
+    steps:
+      - name: Checkout sidewalk
+        uses: actions/checkout@v3
+        with:
+          path: sidewalk
+          ref: main
+      
+      - name: Checkout nrf
+        uses: actions/checkout@v3
+        with:
+          repository: nrfconnect/sdk-nrf
+          path: nrf
+          ref: main
+
+      - name: Change nrf revision
+        run: |
+          nrf_hash="$(git -C nrf rev-parse HEAD)"
+          python3 sidewalk/scripts/ci/replace_nrf_revision_in_west.py -r $nrf_hash sidewalk/west.yml 
+      - name: Get Date
+        id: date
+        run: |
+          echo "date=$(date +%Y_%d_%m)" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{secrets.NCS_GITHUB_TOKEN}}
+          path: sidewalk
+          commit-message: "NRF: upmerge\n\nupdate nrf revision in west.yml"
+          title: "NRF upmerge ${{steps.date.outputs.date}}"
+          body: "PR created automatically by GitHub actions to change revision of NRF in west.yml"
+          delete-branch: true
+          branch: nrf_upmerge-${{steps.date.outputs.date}}
+          signoff: true

--- a/scripts/ci/replace_nrf_revision_in_west.py
+++ b/scripts/ci/replace_nrf_revision_in_west.py
@@ -2,16 +2,28 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-import yaml
 import sys
+from ruamel.yaml import YAML
+import argparse
 
-manifest = dict()
-with open(sys.argv[1], "r") as f:
-    manifest = yaml.safe_load(f)
+parser = argparse.ArgumentParser(
+    description='Modify revision of NRF in west.yml')
+
+parser.add_argument('manifest_path', help="path to west.yml to modify")
+parser.add_argument('-r', '--revision', default="main",
+                    help="git hash, branch name or tag")
+
+args = parser.parse_args()
+
+yml = YAML(typ='rt')
+yml.indent(mapping=2, sequence=4, offset=2)
+
+with open(args.manifest_path, "r") as f:
+    manifest = yml.load(f)
 
 nrf = filter(lambda a: a["name"] == "nrf", manifest["manifest"]["projects"])
 # I expect that there will be 1 such element, if not exeption will be thrown by next()
-next(nrf)["revision"] = "main"
+next(nrf)["revision"] = args.revision
 
-with open(sys.argv[1], "w") as f:
-    yaml.dump(manifest, f)
+with open(args.manifest_path, "w") as f:
+    yml.dump(manifest, f)


### PR DESCRIPTION
KRKNWK-14753
On every Sunday at 01:00 create PR with the changed version of NRF to the most up to date revision.

The PR will trigger standard PR actions, so build check by github, and tests on Jenkins

- [x] Auto create PR with updated west.yaml (the newest sdk-nrf)
- [x] Name PR NCS_upmerge-YYMMDD
- [x] Github action will label this PR as manifest
- [x] Github will run CI
- [ ] If all CI and checks pass - auto-merge - Require automerge feature in repo settings, and current settings require at list 1 approval, so in current configuration it is impossible