### PR TITLE
GitHub: increase paralel matrix for slowest job

### DIFF
--- a/.github/workflows/common_build_samples.yml
+++ b/.github/workflows/common_build_samples.yml
@@ -63,10 +63,10 @@ jobs:
   Build_tests_for_boards:
     strategy:
       matrix:
-        subset: [1, 2, 3]
+        subset: [1, 2, 3, 4, 5]
         platform: [nrf52840dk_nrf52840]
     env:
-      MAX_SUBSETS: 3
+      MAX_SUBSETS: 5
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Building step 2/3 of tests takes almost twice the time of other steps. It is therefore the bottle neck, by spliting this job to more tasks, it will distribute the load more evently and reduce the build time