### PR TITLE
Scripts: fix generation of hardware map for twister UT

### DIFF
--- a/scripts/ci/fill_hardware_map.py
+++ b/scripts/ci/fill_hardware_map.py
@@ -7,7 +7,13 @@ import subprocess
 
 import yaml
 import argparse
+import logging
 
+from packaging import version
+
+logging.basicConfig(level=logging.INFO)
+
+MIN_PCA10056_REVISION = "2.0.0"
 
 pca_to_board = {
     "PCA10056": "nrf52840dk_nrf52840",
@@ -38,13 +44,21 @@ def main(hardware_map_path: str, userdev_conf_path: str):
                               AUTO key to generate hardware-map basis on connected HW
     :return:
     """
+    logging.info("Generating hardware map...")
     if userdev_conf_path.upper() != "AUTO":
         with open(userdev_conf_path) as ud_file:
             userdev_conf = yaml.safe_load(ud_file)["devices"]
 
-        # remove io_testers. We don't want to run tests on io_testers
         for ud_entry in userdev_conf:
             if ud_entry.get("boards", None):
+                # remove io_testers. We don't want to run tests on io_testers
+                logging.info(f"remove io_tester {ud_entry}")
+                userdev_conf.remove(ud_entry)
+            elif ud_entry.get("pca", None) == "PCA10056" and version.parse(
+                ud_entry.get("revision", "0.0.1")
+            ) < version.parse(MIN_PCA10056_REVISION):
+                # remove too old gravitons
+                logging.info(f"remove {ud_entry} since is too old")
                 userdev_conf.remove(ud_entry)
 
     with open(hardware_map_path) as hw_file:
@@ -56,41 +70,61 @@ def main(hardware_map_path: str, userdev_conf_path: str):
         segger = hw_entry["id"].lstrip("0")
         matched_pcas = []
         if userdev_conf_path.upper() != "AUTO":
-            matched_pcas = [ud_entry["pca"] for ud_entry in userdev_conf if str(
-                ud_entry.get("segger")) == segger]
+            matched_pcas = [
+                ud_entry["pca"]
+                for ud_entry in userdev_conf
+                if str(ud_entry.get("segger")) == segger and "pca" in ud_entry
+            ]
         else:
+            # Read out device family
+            out = subprocess.run(
+                ["nrfjprog", "--deviceversion", "--snr", segger], capture_output=True)
+            family_string = out.stdout.decode("utf-8").split("_")[0]
+            matched_pcas = (
+                [family_to_pca[family_string]
+                 ] if out.returncode == 0 and family_string in family_to_pca else []
+            )
+        if matched_pcas:
             # recover DK
+            logging.debug(
+                "Call nrfjprog --recover to check if board is operable.")
             recover = subprocess.run(
                 ["nrfjprog", "--recover", "--snr", segger], capture_output=True)
             if recover.returncode != 0:
                 # it is OK to continue if recovery fail. This DK will not be taken to test
+                logging.warning(
+                    f"Not possible to recover {segger} board, remove from available boards.")
                 continue
-            # Read out device family
-            out = subprocess.run(
-                ["nrfjprog", "--deviceversion", "--snr", segger], capture_output=True)
-            matched_pcas = [family_to_pca[out.stdout.decode(
-                "utf-8").split("_")[0]]] if out.returncode == 0 else []
-        if matched_pcas:
             try:
                 hw_entry["platform"] = pca_to_board[matched_pcas[0]]
             except KeyError:
-                # if platform not known, not supported - remove it
+                logging.warning(
+                    f"platform not known or not supported {segger}")
                 to_remove.append(hw_entry)
                 continue
             # Collect all entries for nRF53 DKs
             if "nrf5340dk_nrf5340_cpuapp" in hw_entry["platform"]:
                 # If older nRF53 board (3 serial IFs), remove first and second serial interface
                 if segger.startswith("9601"):
-                    if "-if00" in hw_entry["serial"]:
+                    logging.info(
+                        f"Remove first and second serial interface for old nRF53 board {segger}")
+                    if hw_entry["serial"] and "-if00" in hw_entry["serial"]:
                         to_remove.append(hw_entry)
-                    elif "-if02" in hw_entry["serial"]:
+                    elif hw_entry["serial"] and "-if02" in hw_entry["serial"]:
                         to_remove.append(hw_entry)
                 # If newer nRF53 board, remove only first serial interface
                 elif segger.startswith("10500"):
+                    logging.info(
+                        f"Remove first serial interface for nRF53 board {segger}")
                     if "-if00" in hw_entry["serial"]:
                         to_remove.append(hw_entry)
                 else:
-                    print("Unrecognized version of nRF53 board.")
+                    logging.warning(
+                        f"Unrecognized version of nRF53 board {segger}")
+            elif "nrf52840dk_nrf52840" in hw_entry["platform"]:
+                # If newer nRF52 board, remove first serial interface
+                if segger.startswith("1050") and "-if02" in hw_entry["serial"]:
+                    to_remove.append(hw_entry)
         else:
             # HW not known or not connected. Mark for removal
             to_remove.append(hw_entry)
@@ -101,7 +135,8 @@ def main(hardware_map_path: str, userdev_conf_path: str):
 
     with open(f"{hardware_map_path}_filled", "w") as hw_file:
         yaml.dump(hardware_map, hw_file)
-    print("End")
+    logging.info(f"Final hardware_map content: {hardware_map}")
+    logging.info("End")
 
 
 if __name__ == "__main__":
@@ -119,7 +154,8 @@ if __name__ == "__main__":
         "--hardware_map_path",
         required=True,
         type=str,
-        help="Available HW generated by twister command: --generate-hardware-map hardware-map.yaml --persistent-hardware-map",
+        help="Available HW generated by twister command: --generate-hardware-map\
+             hardware-map.yaml --persistent-hardware-map",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
recover boards for both modes AUTO and user_devconf passed as parameter to run_ut.sh 
remove additional debug port for the newest nrf52 boards 
do not use nrf52840 <2.0.0
use logging module

Signed-off-by: Tomasz Tyzenhauz <tomasz.tyzenhauz@nordicsemi.no>