### PR TITLE
tests: add build_only flag for manual tests on DUT

### DIFF
--- a/tests/manual/ble/sample.yaml
+++ b/tests/manual/ble/sample.yaml
@@ -4,6 +4,7 @@ sample:
 tests:
   sidewalk.test.ble:
     platform_allow: nrf52840dk_nrf52840
+    build_only: true
     integration_platforms:
       - nrf52840dk_nrf52840
     tags: Sidewalk

--- a/tests/manual/log/sample.yaml
+++ b/tests/manual/log/sample.yaml
@@ -4,6 +4,7 @@ sample:
 tests:
   sidewalk.test.log:
     platform_allow: nrf52840dk_nrf52840
+    build_only: true
     integration_platforms:
       - nrf52840dk_nrf52840
     tags: Sidewalk


### PR DESCRIPTION
two manual tests did not have build_only flag,
and automated test framework failed on attempt to run those tests (Those tests do not use any standard framework, and require human to assess the output and verify if it is correct)