### PR TITLE
vscode: add lldb and doxygen to devenvironment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,9 @@
 				"ms-vscode.live-server",
 				"GitHub.vscode-pull-request-github",
 				"ms-python.python",
-				"ryanluker.vscode-coverage-gutters"
+				"ryanluker.vscode-coverage-gutters",
+				"vadimcn.vscode-lldb",
+				"cschlosser.doxdocgen"
 			],
 			"settings": {
 				"github.gitAuthentication": true,
@@ -53,7 +55,16 @@
 					"coverage.info",
 					"lcov.info"
 				],
-				"editor.tabSize": 8
+				"editor.tabSize": 8,
+				"doxdocgen.file.copyrightTag": [
+					"Copyright (c) {year} Nordic Semiconductor ASA",
+					"",
+					"SPDX-License-Identifier: LicenseRef-Nordic-5-Clause"
+				],
+				"doxdocgen.file.fileOrder": [
+					"copyright",
+					"custom"
+				]
 			}
 		}
 	},


### PR DESCRIPTION
lldb enalbes debugging for native posix.
If clangd is used, plugin C/C++ which usualy provides debugger for native application is disabled. LLDB is used instead in that case.

Doxygen helps with commenting functions and file headers.