### PR TITLE
GH: run only hw tests on self hosted node

### DIFF
--- a/.github/workflows/common-run-tests.yml
+++ b/.github/workflows/common-run-tests.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          zephyr/scripts/twister -vvv --inline-logs --test-only --hardware-map /hw_settings/hardware_map.yaml --device-testing -T sidewalk/tests --retry-failed 2
+          zephyr/scripts/twister --exclude-platform native_posix --exclude-platform unit_testing -vvv --inline-logs --test-only --hardware-map /hw_settings/hardware_map.yaml --device-testing -T sidewalk/tests --retry-failed 2
 
       - name: Upload test results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
exclude native posix, and unit testing, as it is tested in other node