### PR TITLE
scripts: Extend run_ut script by selecting platform to use

### DIFF
--- a/scripts/ci/run_ut.sh
+++ b/scripts/ci/run_ut.sh
@@ -27,13 +27,14 @@ RUN_UT=false
 RUN_ON_HW=false
 USERDEV_CONF_FILE="$CURRENT_DIR/../TargetTestsDevConf/user_devconf.yml"
 TWISTER_TAGS=""
+TWISTER_PLATFORM=""
 
 LCOV_EXCLUDE=('/**/twister-out/*' '/**/mbedtls/*' '/**/test/cmock/*' '/**/zephyr/*')
 
 usage () {
   echo ""
   echo "Twister test case runner"
-	echo "Usage: [-s SIDEWALK_SDK_DIR] [-t TESTCASE_ROOT] [-b] [-u] [-f USERDEV_CONF_FILE] [-a TAG]"
+	echo "Usage: [-s SIDEWALK_SDK_DIR] [-t TESTCASE_ROOT] [-b] [-u] [-f USERDEV_CONF_FILE] [-a TAG] [-p PLATFORM]"
 	echo ""
 }
 
@@ -45,11 +46,12 @@ descr () {
 	echo "    -u run unit tests on native_posix. Use testcase-root SIDEWALK_SDK_DIR/tests/unit_tests"
 	echo "    -f run unit tests functional on nRF HW. Use testcase-root SIDEWALK_SDK_DIR/tests/functional"
     echo "    -a run build or tests only for entries with selected tag. It can be passed multiple times, ones per tag. e.g. -a Sidewalk -a Sidewalk_cli"
+    echo "    -p run build or tests only for selected platforms. It can be passed multiple times, e.g. -p nrf5340dk_nrf5340_cpuapp"    
 	echo ""
 }
 
 # Parse opts
-while getopts "s::t::f::a::ubh" opt
+while getopts "s::t::f::a::p::ubh" opt
 do
 	case $opt in
 		s)
@@ -69,6 +71,9 @@ do
         a)
             TWISTER_TAGS="${TWISTER_TAGS}--tag ${OPTARG} "
             ;;            
+        p)
+            TWISTER_PLATFORM="${TWISTER_PLATFORM}--platform ${OPTARG} "
+            ;;             
 		u)
 			RUN_UT=true
 			;;
@@ -90,7 +95,7 @@ done
 
 function run_twister ()
 {
-    local cmd="$TWISTER_BIN -vvv -O ${CURRENT_DIR}/twister-out $TWISTER_TAGS $*"
+    local cmd="$TWISTER_BIN -vvv -O ${CURRENT_DIR}/twister-out $TWISTER_TAGS $TWISTER_PLATFORM $*"
     echo "${cmd}"
     ${cmd} || { return $?; }
     return 0


### PR DESCRIPTION
Add new parameter -p which can be used to narrow twister to work only with selected platforms. It can be passed multiple times.