### PR TITLE
samples/applications: Replace Kconfig

### DIFF
--- a/scripts/generate_version_info_overlay.py
+++ b/scripts/generate_version_info_overlay.py
@@ -21,4 +21,4 @@ if git_describe_cmd.returncode != 0:
 version = git_describe_cmd.stdout.decode("utf-8")
 version_numbers = subtext(version, r"v(\d+\.\d+\.\d+)", "0.0.0") + \
     "+" + subtext(version, r"v[\d\.]+-(\d+)", "0")
-print(f"CONFIG_MCUBOOT_IMAGE_VERSION=\"{version_numbers}\"")
+print(f"CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION=\"{version_numbers}\"")


### PR DESCRIPTION
Replaces the old NCS-specific Kconfig CONFIG_MCUBOOT_IMAGE_VERSION with the upstream zephyr CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION one when signing an image for MCUboot.