### PR TITLE
Build: remove deprecated Kconfig option

### DIFF
--- a/Kconfig.dependencies
+++ b/Kconfig.dependencies
@@ -283,6 +283,3 @@ config USB_DEVICE_INITIALIZE_AT_BOOT
 	default n
 
 endif # SIDEWALK_DFU_SERVICE_USB
-
-config UART_1_NRF_UARTE
-    default n


### PR DESCRIPTION
fixing build configuration for NRF PR
https://github.com/nrfconnect/sdk-nrf/pull/12112