### PR TITLE
Build: use minimal libc in bootloader

### DIFF
--- a/Kconfig.dependencies
+++ b/Kconfig.dependencies
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+choice LIBC_IMPLEMENTATION
+	default NEWLIB_LIBC
+endchoice
+
 config SIDEWALK_SUBGHZ
 	bool
 	default SIDEWALK && (SIDEWALK_LINK_MASK_FSK || SIDEWALK_LINK_MASK_LORA)

--- a/samples/common/Kconfig.mcuboot.defaults
+++ b/samples/common/Kconfig.mcuboot.defaults
@@ -36,13 +36,17 @@ config FPROTECT
 config BOOT_MAX_IMG_SECTORS
     default 128
 
-config MINIMAL_LIBC_CALLOC
+choice LIBC_IMPLEMENTATION
+	default MINIMAL_LIBC
+endchoice
+
+config COMMON_LIBC_CALLOC
     default y
 
-config MINIMAL_LIBC_MALLOC
+config COMMON_LIBC_MALLOC
     default y
 
-config MINIMAL_LIBC_REALLOCARRAY
+config COMMON_LIBC_REALLOCARRAY
     default y
 
 config NCS_SAMPLES_DEFAULTS

--- a/samples/common/Kconfig.mcuboot.external_flash.defaults
+++ b/samples/common/Kconfig.mcuboot.external_flash.defaults
@@ -47,13 +47,17 @@ config BOOT_MAX_IMG_SECTORS
 config LOG
     default n
 
-config MINIMAL_LIBC_CALLOC
+choice LIBC_IMPLEMENTATION
+	default MINIMAL_LIBC
+endchoice
+
+config COMMON_LIBC_CALLOC
     default y
 
-config MINIMAL_LIBC_MALLOC
+config COMMON_LIBC_MALLOC
     default y
 
-config MINIMAL_LIBC_REALLOCARRAY
+config COMMON_LIBC_REALLOCARRAY
     default y
 
 config NCS_SAMPLES_DEFAULTS

--- a/samples/sid_dut/child_image/hci_rpmsg/Kconfig.root
+++ b/samples/sid_dut/child_image/hci_rpmsg/Kconfig.root
@@ -7,5 +7,5 @@
 # The purpose of this file is to create a wrapper Kconfig file that will be set as
 # hci_rpmsg_KCONFIG_ROOT and processed before any other Kconfig for hci_rpmsg child image.
 
-rsource "../../../common/Kconfig.hci_rpmsg.defaults"
+rsource "${ZEPHYR_BASE}/../sidewalk/samples/common/Kconfig.hci_rpmsg.defaults"
 source "Kconfig.zephyr"

--- a/samples/template_ble/child_image/mcuboot/Kconfig.root
+++ b/samples/template_ble/child_image/mcuboot/Kconfig.root
@@ -7,5 +7,5 @@
 # The purpose of this file is to create a wrapper Kconfig file that will be set as
 # mcuboot_KCONFIG_ROOT and processed before any other Kconfig for mcuboot child image.
 
-rsource "../../../common/Kconfig.mcuboot.defaults"
+source "${ZEPHYR_BASE}/../sidewalk/samples/common/Kconfig.mcuboot.defaults"
 source "${ZEPHYR_BASE}/../bootloader/mcuboot/boot/zephyr/Kconfig"

--- a/samples/template_subghz/child_image/mcuboot/Kconfig.root
+++ b/samples/template_subghz/child_image/mcuboot/Kconfig.root
@@ -7,5 +7,5 @@
 # The purpose of this file is to create a wrapper Kconfig file that will be set as
 # mcuboot_KCONFIG_ROOT and processed before any other Kconfig for mcuboot child image.
 
-rsource "../../../common/Kconfig.mcuboot.external_flash.defaults"
+source "${ZEPHYR_BASE}/../sidewalk/samples/common/Kconfig.mcuboot.external_flash.defaults"
 source "${ZEPHYR_BASE}/../bootloader/mcuboot/boot/zephyr/Kconfig"


### PR DESCRIPTION
remove deprecated config and use minimal libc for bootloader

Prepared changes for upmerge [#12112](https://github.com/nrfconnect/sdk-nrf/pull/12112)