### PR TITLE
pal: Remove MTU request from nRF to gateway

### DIFF
--- a/Kconfig.dependencies
+++ b/Kconfig.dependencies
@@ -38,7 +38,6 @@ config SIDEWALK_BLE
 	imply BT
 	imply SETTINGS
 	imply BT_PERIPHERAL
-	imply BT_GATT_CLIENT
 	help
 		Sidewalk Bluetooth Low Energy (BLE) module
 
@@ -151,7 +150,7 @@ config SIDEWALK_CRITICAL_REGION_RE_ENTRY_MAX
 	int
 	default 8
 	help
-	  Maximum nesting level of critical region 
+	  Maximum nesting level of critical region
 	  If the nesting level becomes greater than set by this config, assert will be triggered.
 
 endif # SIDEWALK_CRITICAL_REGION

--- a/subsys/sal/sid_pal/src/sid_ble_connection.c
+++ b/subsys/sal/sid_pal/src/sid_ble_connection.c
@@ -33,13 +33,6 @@ static struct bt_conn_cb conn_callbacks = {
 
 static struct bt_gatt_cb gatt_callbacks = { .att_mtu_updated = ble_mtu_cb };
 
-static struct bt_gatt_exchange_params exchange_params;
-
-static void exchange_func(struct bt_conn *conn, uint8_t err, struct bt_gatt_exchange_params *params)
-{
-	LOG_INF("Exchange MTU finished err status: %d", err);
-}
-
 /**
  * @brief The function is called when a new connection is established.
  *
@@ -64,12 +57,7 @@ static void ble_connect_cb(struct bt_conn *conn, uint8_t err)
 
 	k_mutex_lock(&bt_conn_mutex, K_FOREVER);
 	conn_params.conn = bt_conn_ref(conn);
-	exchange_params.func = exchange_func;
-	int error = bt_gatt_exchange_mtu(conn_params.conn, &exchange_params);
 
-	if (error) {
-		LOG_WRN("bt_gatt_exchange_mtu: %d", error);
-	}
 	sid_ble_adapter_conn_connected((const uint8_t *)conn_params.addr);
 	k_mutex_unlock(&bt_conn_mutex);
 

--- a/tests/unit_tests/pal_ble_adapter/src/main.c
+++ b/tests/unit_tests/pal_ble_adapter/src/main.c
@@ -27,7 +27,6 @@ FAKE_VALUE_FUNC(int, bt_enable, bt_ready_cb_t);
 FAKE_VALUE_FUNC(int, bt_disable);
 FAKE_VALUE_FUNC(int, bt_le_adv_start, const struct bt_le_adv_param *, const struct bt_data *,
 		size_t, const struct bt_data *, size_t);
-FAKE_VALUE_FUNC(int, bt_gatt_exchange_mtu, struct bt_conn *, struct bt_gatt_exchange_params *);
 
 FAKE_VALUE_FUNC(int, bt_le_adv_stop);
 FAKE_VOID_FUNC(bt_conn_cb_register, struct bt_conn_cb *);
@@ -48,7 +47,6 @@ FAKE_VALUE_FUNC(ssize_t, bt_gatt_attr_write_ccc, struct bt_conn *, const struct 
 	FAKE(bt_disable)                                                                           \
 	FAKE(bt_le_adv_start)                                                                      \
 	FAKE(bt_le_adv_stop)                                                                       \
-	FAKE(bt_gatt_exchange_mtu)                                                                 \
 	FAKE(bt_conn_cb_register)                                                                  \
 	FAKE(bt_conn_ref)                                                                          \
 	FAKE(bt_conn_unref)                                                                        \

--- a/tests/unit_tests/sid_ble_connection/src/main.c
+++ b/tests/unit_tests/sid_ble_connection/src/main.c
@@ -24,7 +24,6 @@ FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_ref, struct bt_conn *);
 FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
 FAKE_VALUE_FUNC(const bt_addr_le_t *, bt_conn_get_dst, const struct bt_conn *);
 FAKE_VALUE_FUNC(int, bt_conn_disconnect, struct bt_conn *, uint8_t);
-FAKE_VALUE_FUNC(int, bt_gatt_exchange_mtu, struct bt_conn *, struct bt_gatt_exchange_params *);
 
 #define FFF_FAKES_LIST(FAKE)                                                                       \
 	FAKE(bt_conn_cb_register)                                                                  \
@@ -32,8 +31,7 @@ FAKE_VALUE_FUNC(int, bt_gatt_exchange_mtu, struct bt_conn *, struct bt_gatt_exch
 	FAKE(bt_conn_ref)                                                                          \
 	FAKE(bt_conn_unref)                                                                        \
 	FAKE(bt_conn_get_dst)                                                                      \
-	FAKE(bt_conn_disconnect)                                                                   \
-	FAKE(bt_gatt_exchange_mtu)
+	FAKE(bt_conn_disconnect)
 
 #define CONNECTED (true)
 #define DISCONNECTED (false)


### PR DESCRIPTION
[KRKNWK-17600]
Disable client features, including att mtu requests. Now the MTU request are made by gateway, nRF responds. It is observed the connection with gateway works better this way.

[KRKNWK-17600]: https://nordicsemi.atlassian.net/browse/KRKNWK-17600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ