### PR TITLE
Sample: Add Thingy53 for Sensor monitor

### DIFF
--- a/samples/sensor_monitoring/boards/thingy53_nrf5340_cpuapp.conf
+++ b/samples/sensor_monitoring/boards/thingy53_nrf5340_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_BOOTLOADER_MCUBOOT=n
+
+CONFIG_I2C=y
+CONFIG_SENSOR=y
+CONFIG_BME680=y

--- a/samples/sensor_monitoring/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/sensor_monitoring/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
+&i2c1 {
+	status = "okay";
+
+	bme688@76 {
+		compatible = "bosch,bme680";
+		reg = <0x76>;
+		status = "okay";
+	};
+};

--- a/samples/sensor_monitoring/include/sm_buttons.h
+++ b/samples/sensor_monitoring/include/sm_buttons.h
@@ -9,8 +9,11 @@
 
 #include <sm_task.h>
 
+#if defined(CONFIG_BOARD_THINGY53_NRF5340_CPUAPP)
+#define DEMO_BUTTONS_MAX 1
+#else
 #define DEMO_BUTTONS_MAX 4
-
+#endif
 /**
  * @brief Action response process.
  *

--- a/samples/sensor_monitoring/sample.yaml
+++ b/samples/sensor_monitoring/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
   sample.sidewalk.demo.ble:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp thingy53_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp

--- a/samples/sensor_monitoring/src/sm_buttons.c
+++ b/samples/sensor_monitoring/src/sm_buttons.c
@@ -41,6 +41,7 @@ static void btn_event_handler(uint32_t event)
 	case BTN_EVENT_KEY_0:
 		BTN_CHECK_AND_SET_MASK(0);
 		break;
+#ifndef CONFIG_BOARD_THINGY53_NRF5340_CPUAPP
 	case BTN_EVENT_KEY_1:
 		BTN_CHECK_AND_SET_MASK(1);
 		break;
@@ -50,6 +51,7 @@ static void btn_event_handler(uint32_t event)
 	case BTN_EVENT_KEY_3:
 		BTN_CHECK_AND_SET_MASK(3);
 		break;
+#endif
 	default:
 		break;
 	}
@@ -166,10 +168,12 @@ int sm_buttons_init()
 {
 	button_set_action_long_press(DK_BTN1, btn_event_handler, BTN_EVENT_RESET_KEY);
 	button_set_action_short_press(DK_BTN1, btn_event_handler, BTN_EVENT_KEY_0);
+#ifndef CONFIG_BOARD_THINGY53_NRF5340_CPUAPP
+	button_set_action_long_press(DK_BTN1, btn_event_handler, BTN_EVENT_RESET_KEY);
 	button_set_action(DK_BTN2, btn_event_handler, BTN_EVENT_KEY_1);
 	button_set_action(DK_BTN3, btn_event_handler, BTN_EVENT_KEY_2);
 	button_set_action(DK_BTN4, btn_event_handler, BTN_EVENT_KEY_3);
-
+#endif
 	for (size_t i = 0; i < DEMO_BUTTONS_MAX; i++) {
 		button_id_arr[i] = i;
 	}

--- a/samples/sensor_monitoring/src/sm_leds.c
+++ b/samples/sensor_monitoring/src/sm_leds.c
@@ -9,8 +9,11 @@
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sm_leds, CONFIG_SIDEWALK_LOG_LEVEL);
-
+#if defined(CONFIG_BOARD_THINGY53_NRF5340_CPUAPP)
+#define DEMO_LEDS_MAX 3
+#else
 #define DEMO_LEDS_MAX 4
+#endif
 #define LED_ACTION_REPONSE_PAYLOAD_SIZE_MAX 32
 
 static int leds_state;


### PR DESCRIPTION
[KRKNWK-17773]
Add Thingy with Bosh temperature sensor

Co-authored-by:Krzysztof Taborowski <krzysztof.taborowski@nordicsemi.no>

[KRKNWK-17773]: https://nordicsemi.atlassian.net/browse/KRKNWK-17773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ