### PR TITLE
samples: increase ipc thread priority

### DIFF
--- a/samples/sensor_monitoring/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/sensor_monitoring/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
  sid_semtech: &spi4 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";

--- a/samples/sid_dut/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/sid_dut/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
  sid_semtech: &spi4 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";

--- a/samples/sid_dut/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/sid_dut/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
  sid_semtech: &spi4 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
@@ -14,7 +20,7 @@
 };
 
 /{
-			
+
 	semtech_sx1262_gpios{
 		compatible = "gpio-keys";
 	   semtech_sx1262_cs: cs {

--- a/samples/template_ble/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/template_ble/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+ #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
+
+ &ipc0 {
+	 zephyr,priority = <0 PRIO_COOP>;
+ };
+
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;

--- a/samples/template_subghz/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/template_subghz/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
  sid_semtech: &spi4 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";


### PR DESCRIPTION
Set IPC thread priority to the highest value
to not collide with other threads.
Workaround for nRF53 know issue
when BLE and Flash operations are performed at the same time

Copied form https://github.com/nrfconnect/sdk-nrf/blob/3003f42ee1a14ac6ca6f3cb6990ea2fcc05bb6a7/samples/matter/template/boards/nrf5340dk_nrf5340_cpuapp.overlay#L15