### PR TITLE
tests: nRF52  wont suspend flash to save power

### DIFF
--- a/tests/manual/power/src/main.c
+++ b/tests/manual/power/src/main.c
@@ -165,11 +165,13 @@ static void app_setup(void)
 	}
 #endif
 
+#if defined(NRF5340_XXAA)
 	const struct device *const qspi_dev = DEVICE_DT_GET(EXTERNAL_FLASH);
 
 	if (device_is_ready(qspi_dev)) {
 		pm_device_action_run(qspi_dev, PM_DEVICE_ACTION_SUSPEND);
 	}
+#endif
 }
 
 static void state_change_handler_power_test(const struct notifier_state *state)

--- a/tests/manual/power_ble_only/src/main.c
+++ b/tests/manual/power_ble_only/src/main.c
@@ -160,7 +160,7 @@ static void app_setup(void)
 	}
 #endif
 
-#if defined(CONFIG_NORDIC_QSPI_NOR)
+#if (defined(CONFIG_NORDIC_QSPI_NOR) && defined(NRF5340_XXAA))
 	const struct device *const qspi_dev = DEVICE_DT_GET(EXTERNAL_FLASH);
 
 	if (device_is_ready(qspi_dev)) {


### PR DESCRIPTION
In power tests external flash will be suspend only on nRF53. This allows to perform usb dfu on nRF52 in Sidewalk mode