### PR TITLE
manifest: update nrf revision with current fix

### DIFF
--- a/internal_west.yml
+++ b/internal_west.yml
@@ -13,7 +13,7 @@ manifest:
     - name: nrf
       repo-path: sdk-nrf
       path: nrf
-      revision: db85d67bf2c9dacf39817a1724937d8c548f1680
+      revision: 0498f8246f059aa807d8a731e3eaabdfc697e6b0
       import: true
 
   # West-related configuration for the sidewalk repository.


### PR DESCRIPTION
[KRKNWK-17935]
See bootloder current fix https://github.com/nrfconnect/sdk-nrf/pull/12825

[KRKNWK-17935]: https://nordicsemi.atlassian.net/browse/KRKNWK-17935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ