### PR TITLE
template_subghz: mcuboot Kconfig.root path changed

### DIFF
--- a/samples/template_subghz/CMakeLists.txt
+++ b/samples/template_subghz/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 include(../common/bootloader_version.cmake)
 
-set(mcuboot_KCONFIG_ROOT $ENV{ZEPHYR_BASE}/../sidewalk/samples/template_subghz/child_image/mcuboot/Kconfig.root)
+set(mcuboot_KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/child_image/mcuboot/Kconfig.root)
 set(hci_rpmsg_KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/child_image/hci_rpmsg/Kconfig.root)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
Changed the path in the mcuboot CMakeLists.txt to
ensure that changes made in a cloned example persist
correctly.

Signed-off-by: Kelly Helmut Lord <helmut@helmutlord.com>
