### PR TITLE
pal: remove misleading log

### DIFF
--- a/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
+++ b/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
@@ -97,9 +97,8 @@ static sid_error_t bus_serial_spi_destroy(const struct sid_pal_serial_bus_iface 
 sid_error_t sid_pal_serial_bus_nordic_spi_create(const struct sid_pal_serial_bus_iface **iface,
 						 const void *cfg)
 {
-	LOG_WRN("%s", __func__);
-
 	ARG_UNUSED(cfg);
+
 	if (!iface) {
 		return SID_ERROR_INVALID_ARGS;
 	}


### PR DESCRIPTION
Remove misleading warning with function name