### PR TITLE
CI: Increase subesets for dut tests

### DIFF
--- a/.github/workflows/common-build_and_run.yml
+++ b/.github/workflows/common-build_and_run.yml
@@ -179,13 +179,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        subset: [1, 2, 3]
+        subset: [1, 2, 3, 4, 5, 6]
         board: ${{ fromJson(inputs.supported_platforms) }}
     uses: ./.github/workflows/DUT_tests.yml
     with:
       change_nrf_revision: ${{ inputs.change_nrf_revision }}
       subset: ${{ matrix.subset }}
-      max_subsets: 3
+      max_subsets: 6
       run_tests: true
       target_board: ${{ matrix.board }}
 


### PR DESCRIPTION
If the cache is too large, it might take too long to restore and cause a timeout. Adding new platform may increase chace size over accepted values.