### PR TITLE
utils: remove sleep from dfu timer callback

### DIFF
--- a/utils/src/nordic_dfu.c
+++ b/utils/src/nordic_dfu.c
@@ -62,7 +62,6 @@ static void led_action(struct k_timer *timer_id)
 static void exit_dfu_mode(struct k_timer *timer_id)
 {
 	LOG_ERR("DFU did not start or could not complete. Reset to exit dfu mode");
-	k_sleep(K_MSEC(100));
 	sys_reboot(SYS_REBOOT_COLD);
 }
 


### PR DESCRIPTION
Fix for ASSERTION FAIL [!arch_is_in_isr()]
zephyr/kernel/sched.c:1581