### PR TITLE
pal: remove unncessary timer casting

### DIFF
--- a/subsys/sal/sid_pal/src/sid_timer.c
+++ b/subsys/sal/sid_pal/src/sid_timer.c
@@ -60,7 +60,7 @@ static const struct sid_timespec *sid_pal_timer_get_tolerance(sid_pal_timer_prio
 	return tolerance;
 }
 
-static bool sid_pal_timer_list_in_list(sid_pal_timer_t *timer)
+static bool sid_pal_timer_list_in_list(const sid_pal_timer_t *timer)
 {
 	SID_PAL_ASSERT(timer);
 	bool result = true;
@@ -214,9 +214,8 @@ bool sid_pal_timer_is_armed(const sid_pal_timer_t *timer_storage)
 	if (!timer_storage) {
 		return false;
 	}
-	sid_pal_timer_t *timer = (sid_pal_timer_t *)timer_storage;
 
-	return sid_pal_timer_list_in_list(timer);
+	return sid_pal_timer_list_in_list(timer_storage);
 }
 
 void sid_pal_timer_event_callback(void *arg, const struct sid_timespec *now)


### PR DESCRIPTION
Possible fix for sporadic test failures.

```
START - test_sid_pal_timer_arm
Assertion failed at ../../../../../../tests/functional/time/src/main.c:93: time_test_sid_pal_timer_arm: sid_pal_timer_is_armed(&test_timer) is false
```

Casting away a const qualifier can lead to undefined behavior. We are not modifying timer object anyway, co we can use const pointer further.