### PR TITLE
CI: automatically create PR in NRF

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
 ## CI parameters
 
+(branch, hash, pull/XXX/head)
 NRF_revision=main
+
+(true, false)
+Create_NRF_PR=false
 
 ## Description
 

--- a/.github/workflows/on-pr_nrf_manifest_update_PR.yml
+++ b/.github/workflows/on-pr_nrf_manifest_update_PR.yml
@@ -1,0 +1,30 @@
+name: handle manifest PR
+on:
+  pull_request_target:
+    types: [opened, synchronize, closed]
+    branches:
+      - main
+
+jobs:
+  create-manifest-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read body of PR
+        run: printf "%s\n" "${{ github.event.pull_request.body }}" > pr_body.md
+
+      - name: Get nrf revision
+        id: config
+        shell: bash {0}
+        run: |
+          grep -oP "(Create_NRF_PR=)(true|false)" pr_body.md > config
+          if [ $? != 0 ]; then
+            echo "Create_NRF_PR=false" >> $GITHUB_OUTPUT;
+          else
+            cat config >> $GITHUB_OUTPUT;
+          fi;
+
+      - name: Create manifest PR
+        if: ${{steps.config.outcome.Create_NRF_PR == 'true' }}
+        uses: nrfconnect/action-manifest-pr@main
+        with:
+          token: ${{ secrets.NCS_GITHUB_TOKEN }}


### PR DESCRIPTION
if configured, creation of PR in Sidewalk will trigger new PR in NRF. PR in NRF will keep track the state of the PR in Sidewalk.

Remember to delete the PR in NRF if the PR gets closed without merging.

## CI parameters

NRF_revision=main
Create_NRF_PR=true

## Description

JIRA ticket: KRKNWK-18740

Detail description of the change

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized
- [x] Verification
  - [x] Unit tests were updated to include the change.
  - [x] Change has been tested. 
