### PR TITLE
scripts: Add lcov as coverage tool in run_ut script

### DIFF
--- a/scripts/ci/run_ut.sh
+++ b/scripts/ci/run_ut.sh
@@ -139,7 +139,7 @@ function run_ut ()
         echo "[INFO]: Run unit tests not executed"
         return 0
     fi
-    run_twister --platform native_posix --platform unit_testing --coverage --enable-ubsan --enable-lsan --enable-asan -T $(get_testcase_root $(realpath ${SIDEWALK_SDK_DIR}/tests/unit_tests))
+    run_twister --platform native_posix --platform unit_testing --coverage --coverage-tool lcov --enable-ubsan --enable-lsan --enable-asan -T $(get_testcase_root $(realpath ${SIDEWALK_SDK_DIR}/tests/unit_tests))
     status=$?
     echo "[INFO]: Remove files from coverage that are not under test and regenerate html report"
     lcov -q --remove "${CURRENT_DIR}/twister-out/coverage.info" "${LCOV_EXCLUDE[@]}" -o "${CURRENT_DIR}/twister-out/new_coverage.info"


### PR DESCRIPTION
Twister starts use gcov tool by default.
Switch back to lcov

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
