### PR TITLE
sample: fix issue with sending malformed payload on autoconnect

### DIFF
--- a/samples/sid_end_device/include/sidewalk.h
+++ b/samples/sid_end_device/include/sidewalk.h
@@ -6,7 +6,9 @@
 #ifndef SIDEWALK_APP_H
 #define SIDEWALK_APP_H
 
+#include <zephyr/sys/slist.h>
 #include <sid_api.h>
+#include <zephyr/kernel.h>
 
 typedef enum {
 	SID_EVENT_SIDEWALK,
@@ -32,6 +34,7 @@ typedef struct {
 } sidewalk_ctx_t;
 
 typedef struct {
+	sys_snode_t node;
 	struct sid_msg msg;
 	struct sid_msg_desc desc;
 } sidewalk_msg_t;
@@ -45,5 +48,7 @@ typedef struct {
 void sidewalk_start(sidewalk_ctx_t *context);
 
 int sidewalk_event_send(sidewalk_event_t event, void *ctx);
+
+sidewalk_msg_t *get_message_buffer(uint16_t message_id);
 
 #endif /* SIDEWALK_APP_H */

--- a/samples/sid_end_device/src/cli/app.c
+++ b/samples/sid_end_device/src/cli/app.c
@@ -40,6 +40,13 @@ static void on_sidewalk_msg_sent(const struct sid_msg_desc *msg_desc, void *cont
 	LOG_INF("Message send success");
 	printk(JSON_NEW_LINE(JSON_OBJ(JSON_NAME(
 		"on_msg_sent", JSON_OBJ(JSON_VAL_sid_msg_desc("sid_msg_desc", msg_desc, 0))))));
+	sidewalk_msg_t *message = get_message_buffer(msg_desc->id);
+	if (message == NULL) {
+		LOG_ERR("failed to find message buffer to clean");
+		return;
+	}
+	sid_hal_free(message->msg.data);
+	sid_hal_free(message);
 }
 
 static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc *msg_desc,
@@ -50,6 +57,13 @@ static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc 
 		"on_send_error",
 		JSON_OBJ(JSON_LIST_2(JSON_VAL_sid_error_t("error", error),
 				     JSON_VAL_sid_msg_desc("sid_msg_desc", msg_desc, 0)))))));
+	sidewalk_msg_t *message = get_message_buffer(msg_desc->id);
+	if (message == NULL) {
+		LOG_ERR("failed to find message buffer to clean");
+		return;
+	}
+	sid_hal_free(message->msg.data);
+	sid_hal_free(message);
 }
 
 static void on_sidewalk_factory_reset(void *context)

--- a/samples/sid_end_device/src/hello/app.c
+++ b/samples/sid_end_device/src/hello/app.c
@@ -90,6 +90,13 @@ static void on_sidewalk_msg_sent(const struct sid_msg_desc *msg_desc, void *cont
 		"on_msg_sent", JSON_OBJ(JSON_VAL_sid_msg_desc("sid_msg_desc", msg_desc, 0))))));
 
 	application_state_sending(&global_state_notifier, false);
+	sidewalk_msg_t *message = get_message_buffer(msg_desc->id);
+	if (message == NULL) {
+		LOG_ERR("failed to find message buffer to clean");
+		return;
+	}
+	sid_hal_free(message->msg.data);
+	sid_hal_free(message);
 }
 
 static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc *msg_desc,
@@ -102,6 +109,14 @@ static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc 
 				     JSON_VAL_sid_msg_desc("sid_msg_desc", msg_desc, 0)))))));
 
 	application_state_sending(&global_state_notifier, false);
+
+	sidewalk_msg_t *message = get_message_buffer(msg_desc->id);
+	if (message == NULL) {
+		LOG_ERR("failed to find message buffer to clean");
+		return;
+	}
+	sid_hal_free(message->msg.data);
+	sid_hal_free(message);
 }
 
 static void on_sidewalk_factory_reset(void *context)

--- a/samples/sid_end_device/src/sensor_monitoring/app.c
+++ b/samples/sid_end_device/src/sensor_monitoring/app.c
@@ -71,6 +71,13 @@ static void on_sidewalk_msg_received(const struct sid_msg_desc *msg_desc, const 
 static void on_sidewalk_msg_sent(const struct sid_msg_desc *msg_desc, void *context)
 {
 	LOG_DBG("sent message(type: %d, id: %u)", (int)msg_desc->type, msg_desc->id);
+	sidewalk_msg_t *message = get_message_buffer(msg_desc->id);
+	if (message == NULL) {
+		LOG_ERR("failed to find message buffer to clean");
+		return;
+	}
+	sid_hal_free(message->msg.data);
+	sid_hal_free(message);
 }
 
 static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc *msg_desc,
@@ -78,6 +85,13 @@ static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc 
 {
 	LOG_ERR("Send message err %d", (int)error);
 	LOG_DBG("Failed to send message(type: %d, id: %u)", (int)msg_desc->type, msg_desc->id);
+	sidewalk_msg_t *message = get_message_buffer(msg_desc->id);
+	if (message == NULL) {
+		LOG_ERR("failed to find message buffer to clean");
+		return;
+	}
+	sid_hal_free(message->msg.data);
+	sid_hal_free(message);
 }
 
 static void on_sidewalk_factory_reset(void *context)


### PR DESCRIPTION

The issue has been investigated, and it was caused by the `sid_put_msg` performing shallow copy of the data to send. This was not intended, and will be fixed in next release.

Temporary fix for this issue, is to track the payload passed to `sid_put_msg` and free it when message has been send, or when there will be no further attempts with sending.

So this commit is temporary and should be reverted for the next release.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 
KRKNWK-18805
KRKNWK-19016

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
