### PR TITLE
DFU: transmit device name in scan response packet

### DIFF
--- a/utils/src/nordic_dfu.c
+++ b/utils/src/nordic_dfu.c
@@ -27,6 +27,10 @@ static const struct bt_data ad[] = {
 		      0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static enum led_status_e {
 	LED_TOGGLE_ALL,
 	LED_LOADING_WHEEL,
@@ -123,7 +127,7 @@ int nordic_dfu_ble_start(void)
 
 	mgmt_callback_register(&dfu_mode_mgmt_cb);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,  ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Bluetooth advertising start failed (err %d)", err);
 		return err;


### PR DESCRIPTION
## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: true
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 
https://github.com/zephyrproject-rtos/zephyr/pull/71700/files#diff-654399b6eb61835065817cf21e12ceaf86bb0a3d5582a2b85615c079a701dac0R26-R36
file `samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c` is the same functionality, and has the same change.

This additional parameter sd was missed during the upmerge integration


The change has been tested manually, and after entering into DFU mode, the device with proper address starts to advertise as expected. 
Waiting for merge for completion of the Jenkins. 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
