### PR TITLE
mcuboot: add DTS configuration for nrf54 bootloader

### DIFF
--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-
+CONFIG_BOOT_MAX_IMG_SECTORS=256
 # Ensure that the qspi driver is disabled by default
 CONFIG_NORDIC_QSPI_NOR=n
 

--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* There is no aditional config needed for this version of PDK */

--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
+&cpuapp_rram {
+	reg = < 0x0 DT_SIZE_K(1524) >;
+};


### PR DESCRIPTION
with the latest upmerge the additional entry in DTS was required. The change has not been propagated to bootloader configuration. This commit fixes the issue where the application did not swap after DFU.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: true
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
