### PR TITLE
sample: fix issue with memory leak on events

### DIFF
--- a/samples/sid_end_device/include/sidewalk.h
+++ b/samples/sid_end_device/include/sidewalk.h
@@ -24,9 +24,11 @@ typedef enum {
 	SID_EVENT_LAST,
 } sidewalk_event_t;
 
+typedef void (*ctx_free)(void *ctx);
 typedef struct {
 	sidewalk_event_t id;
 	void *ctx;
+	ctx_free ctx_free;
 } sidewalk_ctx_event_t;
 
 typedef struct {
@@ -56,7 +58,7 @@ typedef struct {
 
 void sidewalk_start(sidewalk_ctx_t *context);
 
-int sidewalk_event_send(sidewalk_event_t event, void *ctx);
+int sidewalk_event_send(sidewalk_event_t event, void *ctx, ctx_free free);
 
 sidewalk_msg_t *get_message_buffer(uint16_t message_id);
 

--- a/samples/sid_end_device/src/cli/app.c
+++ b/samples/sid_end_device/src/cli/app.c
@@ -20,7 +20,7 @@ static uint32_t persistent_link_mask;
 
 static void on_sidewalk_event(bool in_isr, void *context)
 {
-	int err = sidewalk_event_send(SID_EVENT_SIDEWALK, NULL);
+	int err = sidewalk_event_send(SID_EVENT_SIDEWALK, NULL, NULL);
 	if (err) {
 		LOG_ERR("Send event err %d", err);
 	};
@@ -81,7 +81,7 @@ static void on_sidewalk_status_changed(const struct sid_status *status, void *co
 	} else {
 		memcpy(new_status, status, sizeof(struct sid_status));
 	}
-	sidewalk_event_send(SID_EVENT_NEW_STATUS, new_status);
+	sidewalk_event_send(SID_EVENT_NEW_STATUS, new_status, sid_hal_free);
 
 	switch (status->state) {
 	case SID_STATE_READY:

--- a/samples/sid_end_device/src/sbdt/file_transfer.c
+++ b/samples/sid_end_device/src/sbdt/file_transfer.c
@@ -76,7 +76,7 @@ static void on_data_received(const struct sid_bulk_data_transfer_desc *const des
 	transfer->data = buffer->data;
 	transfer->data_size = buffer->size;
 
-	int err = sidewalk_event_send(SID_EVENT_FILE_TRANSFER, transfer);
+	int err = sidewalk_event_send(SID_EVENT_FILE_TRANSFER, transfer, sid_hal_free);
 	if (err) {
 		LOG_ERR("Event transfer err %d", err);
 		LOG_INF("Cancelig file transfer");
@@ -117,7 +117,7 @@ static void on_finalize_request(uint32_t file_id, void *context)
 		LOG_ERR("dfu image finalize fail %d", err);
 	}
 
-	err = sidewalk_event_send(SID_EVENT_REBOOT, NULL);
+	err = sidewalk_event_send(SID_EVENT_REBOOT, NULL, NULL);
 	if (err) {
 		LOG_ERR("reboot event send ret %d", err);
 	}

--- a/samples/sid_end_device/src/sensor_monitoring/app.c
+++ b/samples/sid_end_device/src/sensor_monitoring/app.c
@@ -42,7 +42,7 @@ static sidewalk_ctx_t sid_ctx;
 
 static void on_sidewalk_event(bool in_isr, void *context)
 {
-	int err = sidewalk_event_send(SID_EVENT_SIDEWALK, NULL);
+	int err = sidewalk_event_send(SID_EVENT_SIDEWALK, NULL, NULL);
 	if (err) {
 		LOG_ERR("Send event err %d", err);
 	};
@@ -112,7 +112,7 @@ static void on_sidewalk_status_changed(const struct sid_status *status, void *co
 	} else {
 		memcpy(new_status, status, sizeof(struct sid_status));
 	}
-	sidewalk_event_send(SID_EVENT_NEW_STATUS, new_status);
+	sidewalk_event_send(SID_EVENT_NEW_STATUS, new_status, sid_hal_free);
 
 	int err = 0;
 	switch (status->state) {
@@ -165,7 +165,7 @@ static void on_sidewalk_status_changed(const struct sid_status *status, void *co
 
 static void sidewalk_btn_handler(uint32_t event)
 {
-	int err = sidewalk_event_send((sidewalk_event_t)event, NULL);
+	int err = sidewalk_event_send((sidewalk_event_t)event, NULL, NULL);
 	if (err) {
 		LOG_ERR("Send event err %d", err);
 		return;

--- a/tests/unit_tests/sid_dut_shell/mock/sidewalk_mock.h
+++ b/tests/unit_tests/sid_dut_shell/mock/sidewalk_mock.h
@@ -15,7 +15,7 @@ DEFINE_FFF_GLOBALS;
 FAKE_VOID_FUNC(sidewalk_start, sidewalk_ctx_t *);
 FAKE_VALUE_FUNC(void *, sid_hal_malloc, size_t);
 FAKE_VOID_FUNC(sid_hal_free, void *);
-FAKE_VALUE_FUNC(int, sidewalk_event_send, sidewalk_event_t, void *);
+FAKE_VALUE_FUNC(int, sidewalk_event_send, sidewalk_event_t, void *, ctx_free);
 
 #define SIDEWALK_FAKES_LIST(FAKE)                                                                  \
 	FAKE(sidewalk_start)                                                                       \


### PR DESCRIPTION
Some events have context allocated on heap,
but it was not freed in all states.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
