### PR TITLE
sensor_monitor: move app_start_tasks

### DIFF
--- a/samples/sid_end_device/src/sensor_monitoring/app.c
+++ b/samples/sid_end_device/src/sensor_monitoring/app.c
@@ -272,11 +272,10 @@ void app_start(void)
 		.sub_ghz_link_config = app_get_sub_ghz_config(),
 	};
 
+	app_start_tasks();
 	sidewalk_start(&sid_ctx);
 	sidewalk_event_send(sidewalk_event_platform_init, NULL, NULL);
 	sidewalk_event_send(sidewalk_event_autostart, NULL, NULL);
-
-	app_start_tasks();
 
 	k_timer_start(&notify_timer, K_MSEC(NOTIFY_TIMER_DURATION_MS),
 		      K_MSEC(CONFIG_SID_END_DEVICE_NOTIFY_DATA_PERIOD_MS));


### PR DESCRIPTION
## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: test-branch
```

## Description

The tests show that sidewalk state change callback can be called before the tx task is fully initialized, and some events are dropped. Move the initialization of the app_tx thread before the sidewalk starts.

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
