### PR TITLE
log: add name to sid_error_t when printing.

### DIFF
--- a/samples/sid_end_device/src/cli/app_dut.c
+++ b/samples/sid_end_device/src/cli/app_dut.c
@@ -15,6 +15,7 @@
 #ifdef CONFIG_SIDEWALK_FILE_TRANSFER_DFU
 #include <sbdt/dfu_file_transfer.h>
 #endif /* CONFIG_SIDEWALK_FILE_TRANSFER_DFU */
+#include <json_printer/sidTypes2str.h>
 LOG_MODULE_REGISTER(sid_cli, CONFIG_SIDEWALK_LOG_LEVEL);
 
 static uint32_t dut_ctx_get_uint32(void *ctx)
@@ -55,34 +56,34 @@ void dut_event_deinit(sidewalk_ctx_t *sid, void *ctx)
 	app_file_transfer_demo_deinit(sid->handle);
 #endif
 	sid_error_t e = sid_deinit(sid->handle);
-	LOG_INF("sid_deinit returned %d", e);
+	LOG_INF("sid_deinit returned %d (%s)", (int)e, SID_ERROR_T_STR(e));
 }
 void dut_event_start(sidewalk_ctx_t *sid, void *ctx)
 {
 	uint32_t link_mask = dut_ctx_get_uint32(ctx);
 	sid_error_t e = sid_start(sid->handle, link_mask);
-	LOG_INF("sid_start returned %d", e);
+	LOG_INF("sid_start returned %d (%s)", (int)e, SID_ERROR_T_STR(e));
 }
 void dut_event_stop(sidewalk_ctx_t *sid, void *ctx)
 {
 	uint32_t link_mask = dut_ctx_get_uint32(ctx);
 	sid_error_t e = sid_stop(sid->handle, link_mask);
-	LOG_INF("sid_stop returned %d", e);
+	LOG_INF("sid_stop returned %d (%s)", (int)e, SID_ERROR_T_STR(e));
 }
 void dut_event_get_mtu(sidewalk_ctx_t *sid, void *ctx)
 {
 	uint32_t link_mask = dut_ctx_get_uint32(ctx);
 	size_t mtu = 0;
 	sid_error_t e = sid_get_mtu(sid->handle, (enum sid_link_type)link_mask, &mtu);
-	LOG_INF("sid_get_mtu returned %d, MTU: %d", e, mtu);
+	LOG_INF("sid_get_mtu returned %d (%s), MTU: %d", e, SID_ERROR_T_STR(e), mtu);
 }
 void dut_event_get_time(sidewalk_ctx_t *sid, void *ctx)
 {
 	uint32_t format = dut_ctx_get_uint32(ctx);
 	struct sid_timespec curr_time = { 0 };
 	sid_error_t e = sid_get_time(sid->handle, (enum sid_time_format)format, &curr_time);
-	LOG_INF("sid_get_time returned %d, SEC: %d NSEC: %d", e, curr_time.tv_sec,
-		curr_time.tv_nsec);
+	LOG_INF("sid_get_time returned %d (%s), SEC: %d NSEC: %d", e, SID_ERROR_T_STR(e),
+		curr_time.tv_sec, curr_time.tv_nsec);
 }
 void dut_event_get_status(sidewalk_ctx_t *sid, void *ctx)
 {
@@ -122,32 +123,35 @@ void dut_event_get_option(sidewalk_ctx_t *sid, void *ctx)
 	case SID_OPTION_GET_MSG_POLICY_FILTER_DUPLICATES: {
 		uint8_t data = 0;
 		sid_error_t e = sid_option(sid->handle, opt, &data, sizeof(data));
-		LOG_INF("sid_option returned %d; Filter Duplicates: %d", e, data);
+		LOG_INF("sid_option returned %d (%s); Filter Duplicates: %d", e, SID_ERROR_T_STR(e),
+			data);
 	} break;
 	case SID_OPTION_GET_LINK_CONNECTION_POLICY: {
 		uint8_t data = 0;
 		sid_error_t e = sid_option(sid->handle, opt, &data, sizeof(data));
-		LOG_INF("sid_option returned %d; Link Connect Policy: %d", e, data);
+		LOG_INF("sid_option returned %d (%s); Link Connect Policy: %d", e,
+			SID_ERROR_T_STR(e), data);
 	} break;
 	case SID_OPTION_GET_LINK_POLICY_MULTI_LINK_POLICY: {
 		uint8_t data = 0;
 		sid_error_t e = sid_option(sid->handle, opt, &data, sizeof(data));
-		LOG_INF("sid_option returned %d; Link Multi Link Policy: %d", e, data);
+		LOG_INF("sid_option returned %d (%s); Link Multi Link Policy: %d", e,
+			SID_ERROR_T_STR(e), data);
 	} break;
 	case SID_OPTION_GET_STATISTICS: {
 		struct sid_statistics stats = { 0 };
 		sid_error_t e = sid_option(sid->handle, opt, &stats, sizeof(stats));
-		LOG_INF("sid_option returned %d; tx: %d, acks_sent %d, tx_fail: %d, retries: %d, dups: %d, acks_recv: %d rx: %d",
-			e, stats.msg_stats.tx, stats.msg_stats.acks_sent, stats.msg_stats.tx_fail,
-			stats.msg_stats.retries, stats.msg_stats.duplicates,
-			stats.msg_stats.acks_recv, stats.msg_stats.rx);
+		LOG_INF("sid_option returned %d (%s); tx: %d, acks_sent %d, tx_fail: %d, retries: %d, dups: %d, acks_recv: %d rx: %d",
+			e, SID_ERROR_T_STR(e), stats.msg_stats.tx, stats.msg_stats.acks_sent,
+			stats.msg_stats.tx_fail, stats.msg_stats.retries,
+			stats.msg_stats.duplicates, stats.msg_stats.acks_recv, stats.msg_stats.rx);
 	} break;
 	case SID_OPTION_GET_LINK_POLICY_AUTO_CONNECT_PARAMS: {
 		struct sid_link_auto_connect_params params = { 0 };
 		memcpy(&params.link_type, p_option->data, sizeof(uint32_t));
 		sid_error_t e = sid_option(sid->handle, opt, (void *)&params, sizeof(params));
-		LOG_INF("sid_option returned %d; AC Policy, link %d, enable %d priority %d timeout %d",
-			e, params.link_type, params.enable, params.priority,
+		LOG_INF("sid_option returned %d (%s); AC Policy, link %d, enable %d priority %d timeout %d",
+			e, SID_ERROR_T_STR(e), params.link_type, params.enable, params.priority,
 			params.connection_attempt_timeout_seconds);
 	} break;
 	case SID_OPTION_900MHZ_GET_DEVICE_PROFILE: {
@@ -163,14 +167,16 @@ void dut_event_get_option(sidewalk_ctx_t *sid, void *ctx)
 		if (IS_LINK2_PROFILE_ID(dev_cfg.unicast_params.device_profile_id) ||
 		    IS_LINK3_PROFILE_ID(dev_cfg.unicast_params.device_profile_id)) {
 			if (dev_cfg.unicast_params.device_profile_id == SID_LINK2_PROFILE_2) {
-				LOG_INF("sid_option returned %d; Link_profile ID: %d Wndw_cnt: %d Rx_Int = %d",
-					e, dev_cfg.unicast_params.device_profile_id,
+				LOG_INF("sid_option returned %d (%s); Link_profile ID: %d Wndw_cnt: %d Rx_Int = %d",
+					e, SID_ERROR_T_STR(e),
+					dev_cfg.unicast_params.device_profile_id,
 					dev_cfg.unicast_params.rx_window_count,
 					dev_cfg.unicast_params.unicast_window_interval
 						.sync_rx_interval_ms);
 			} else {
-				LOG_INF("sid_option returned %d; Link_profile ID: %d Wndw_cnt: %d",
-					e, dev_cfg.unicast_params.device_profile_id,
+				LOG_INF("sid_option returned %d (%s); Link_profile ID: %d Wndw_cnt: %d",
+					e, SID_ERROR_T_STR(e),
+					dev_cfg.unicast_params.device_profile_id,
 					dev_cfg.unicast_params.rx_window_count);
 			}
 		}
@@ -189,18 +195,18 @@ void dut_event_set_option(sidewalk_ctx_t *sid, void *ctx)
 
 	sid_error_t e =
 		sid_option(sid->handle, p_option->option, p_option->data, p_option->data_len);
-	LOG_INF("sid_option returned %d", e);
+	LOG_INF("sid_option returned %d (%s)", e, SID_ERROR_T_STR(e));
 }
 void dut_event_set_dest_id(sidewalk_ctx_t *sid, void *ctx)
 {
 	uint32_t id = dut_ctx_get_uint32(ctx);
 	sid_error_t e = sid_set_msg_dest_id(sid->handle, id);
-	LOG_INF("sid_set_msg_dest_id returned %d", e);
+	LOG_INF("sid_set_msg_dest_id returned %d (%s)", e, SID_ERROR_T_STR(e));
 }
 void dut_event_conn_req(sidewalk_ctx_t *sid, void *ctx)
 {
 	uint32_t event_req = dut_ctx_get_uint32(ctx);
 	bool conn_req = (event_req == 1U);
 	sid_error_t e = sid_ble_bcn_connection_request(sid->handle, conn_req);
-	LOG_INF("sid_conn_request returned %d", e);
+	LOG_INF("sid_conn_request returned %d (%s)", e, SID_ERROR_T_STR(e));
 }

--- a/samples/sid_end_device/src/hello/app.c
+++ b/samples/sid_end_device/src/hello/app.c
@@ -24,6 +24,7 @@
 #include <zephyr/logging/log.h>
 
 #include <json_printer/sidTypes2Json.h>
+#include <json_printer/sidTypes2str.h>
 
 LOG_MODULE_REGISTER(app, CONFIG_SIDEWALK_LOG_LEVEL);
 
@@ -117,7 +118,7 @@ static void on_sidewalk_msg_sent(const struct sid_msg_desc *msg_desc, void *cont
 static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc *msg_desc,
 				   void *context)
 {
-	LOG_ERR("Message send err %d", (int)error);
+	LOG_ERR("Message send err %d (%s)", (int)error, SID_ERROR_T_STR(error));
 	printk(JSON_NEW_LINE(JSON_OBJ(JSON_NAME(
 		"on_send_error",
 		JSON_OBJ(JSON_LIST_2(JSON_VAL_sid_error_t("error", error),

--- a/samples/sid_end_device/src/sbdt/dfu_file_transfer.c
+++ b/samples/sid_end_device/src/sbdt/dfu_file_transfer.c
@@ -9,6 +9,7 @@
 #include <sidewalk.h>
 #include <sid_hal_memory_ifc.h>
 #include <json_printer/sidTypes2Json.h>
+#include <json_printer/sidTypes2str.h>
 #include <sidewalk_dfu/nordic_dfu_img.h>
 #include <sid_bulk_data_transfer_api.h>
 #include <zephyr/logging/log.h>
@@ -141,7 +142,7 @@ static void on_data_received(const struct sid_bulk_data_transfer_desc *const des
 						      transfer->file_id,
 						      SID_BULK_DATA_TRANSFER_REJECT_REASON_GENERIC);
 		if (ret != SID_ERROR_NONE) {
-			LOG_ERR("Fail to cancel sbdt %d", ret);
+			LOG_ERR("Fail to cancel sbdt %d (%s)", ret, SID_ERROR_T_STR(ret));
 		}
 		sid_hal_free(transfer);
 	}

--- a/samples/sid_end_device/src/sensor_monitoring/app.c
+++ b/samples/sid_end_device/src/sensor_monitoring/app.c
@@ -19,6 +19,7 @@
 #include <zephyr/smf.h>
 #include <zephyr/logging/log.h>
 #include <sid_demo_parser.h>
+#include <json_printer/sidTypes2str.h>
 
 LOG_MODULE_REGISTER(app, CONFIG_SIDEWALK_LOG_LEVEL);
 
@@ -85,7 +86,7 @@ static void on_sidewalk_msg_sent(const struct sid_msg_desc *msg_desc, void *cont
 static void on_sidewalk_send_error(sid_error_t error, const struct sid_msg_desc *msg_desc,
 				   void *context)
 {
-	LOG_ERR("Send message err %d", (int)error);
+	LOG_ERR("Send message err %d (%s)", (int)error, SID_ERROR_T_STR(error));
 	LOG_DBG("Failed to send message(type: %d, id: %u)", (int)msg_desc->type, msg_desc->id);
 	sidewalk_msg_t *message = get_message_buffer(msg_desc->id);
 	if (message == NULL) {

--- a/samples/sid_end_device/src/sensor_monitoring/app_tx.c
+++ b/samples/sid_end_device/src/sensor_monitoring/app_tx.c
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/smf.h>
 #include <zephyr/logging/log.h>
+#include <json_printer/sidTypes2str.h>
 
 LOG_MODULE_REGISTER(app_tx, CONFIG_SIDEWALK_LOG_LEVEL);
 
@@ -70,7 +71,7 @@ static uint32_t time_in_sec_get(void)
 	struct sid_timespec curr_time = { 0 };
 	sid_error_t e = sid_pal_uptime_now(&curr_time);
 	if (e) {
-		LOG_INF("Uptime get failed %d", e);
+		LOG_INF("Uptime get failed %d (%s)", e, SID_ERROR_T_STR(e));
 	}
 
 	return curr_time.tv_sec;
@@ -102,7 +103,8 @@ static int app_tx_demo_msg_send(struct sid_parse_state *state, uint8_t *buffer,
 	sid_parse_state_init(state, msg_buffer, sizeof(msg_buffer));
 	sid_demo_app_msg_serialize(state, demo_desc, &demo_msg);
 	if (state->ret_code != SID_ERROR_NONE) {
-		LOG_DBG("Demo msg serialize failed -%d", state->ret_code);
+		LOG_DBG("Demo msg serialize failed -%d (%s)", state->ret_code,
+			SID_ERROR_T_STR(state->ret_code));
 		return -EINVAL;
 	}
 

--- a/samples/sid_end_device/src/sidewalk_events.c
+++ b/samples/sid_end_device/src/sidewalk_events.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "json_printer/sidTypes2str.h"
 #include <sidewalk.h>
 #include <sid_error.h>
 #include <app_mfg_config.h>
@@ -65,7 +66,7 @@ void sidewalk_event_process(sidewalk_ctx_t *sid, void *ctx)
 	}
 	sid_error_t e = sid_process(sid->handle);
 	if (e) {
-		LOG_ERR("sid process err %d", (int)e);
+		LOG_ERR("sid process err  %d (%s)", (int)e, SID_ERROR_T_STR(e));
 	}
 }
 
@@ -82,7 +83,7 @@ void sidewalk_event_platform_init(sidewalk_ctx_t *sid, void *ctx)
 
 	sid_error_t e = sid_platform_init(&platform_parameters);
 	if (SID_ERROR_NONE != e) {
-		LOG_ERR("Sidewalk Platform Init err: %d", e);
+		LOG_ERR("Sidewalk Platform Init err:  %d (%s)", (int)e, SID_ERROR_T_STR(e));
 		return;
 	}
 	if (app_mfg_cfg_is_valid()) {
@@ -125,13 +126,13 @@ void sidewalk_event_autostart(sidewalk_ctx_t *sid, void *ctx)
 											  "BLE");
 	sid_error_t e = sid_init(&sid->config, &sid->handle);
 	if (e) {
-		LOG_ERR("sid init err %d", (int)e);
+		LOG_ERR("sid init err %d (%s)", (int)e, SID_ERROR_T_STR(e));
 		return;
 	}
 
 	e = sid_start(sid->handle, sid->config.link_mask);
 	if (e) {
-		LOG_ERR("sid start err %d", (int)e);
+		LOG_ERR("sid start err %d (%s)", (int)e, SID_ERROR_T_STR(e));
 	}
 
 #if CONFIG_SID_END_DEVICE_AUTO_CONN_REQ
@@ -179,7 +180,7 @@ void sidewalk_event_factory_reset(sidewalk_ctx_t *sid, void *ctx)
 #endif /* CONFIG_SIDEWALK_PERSISTENT_LINK_MASK */
 	sid_error_t e = sid_set_factory_reset(sid->handle);
 	if (e) {
-		LOG_ERR("sid factory reset err %d", (int)e);
+		LOG_ERR("sid factory reset err  %d (%s)", (int)e, SID_ERROR_T_STR(e));
 	}
 }
 
@@ -222,7 +223,7 @@ void sidewalk_event_send_msg(sidewalk_ctx_t *sid, void *ctx)
 
 	sid_error_t e = sid_put_msg(sid->handle, &p_msg_copy->msg, &p_msg_copy->desc);
 	if (e) {
-		LOG_ERR("sid send err %d", (int)e);
+		LOG_ERR("sid send err %d (%s)", (int)e, SID_ERROR_T_STR(e));
 		sid_hal_free(p_msg_copy->msg.data);
 		sid_hal_free(p_msg_copy);
 		return;
@@ -250,7 +251,7 @@ void sidewalk_event_connect(sidewalk_ctx_t *sid, void *ctx)
 	}
 	sid_error_t e = sid_ble_bcn_connection_request(sid->handle, true);
 	if (e) {
-		LOG_ERR("sid conn req err %d", (int)e);
+		LOG_ERR("sid conn req err %d (%s)", (int)e, SID_ERROR_T_STR(e));
 	}
 }
 void sidewalk_event_link_switch(sidewalk_ctx_t *sid, void *ctx)
@@ -291,20 +292,20 @@ void sidewalk_event_link_switch(sidewalk_ctx_t *sid, void *ctx)
 		(void)sid_process(sid->handle);
 		sid_error_t e = sid_deinit(sid->handle);
 		if (e) {
-			LOG_ERR("sid deinit err %d", (int)e);
+			LOG_ERR("sid deinit err %d (%s)", (int)e, SID_ERROR_T_STR(e));
 		}
 	}
 
 	sid_error_t e = sid_init(&sid->config, &sid->handle);
 	if (e) {
-		LOG_ERR("sid init err %d", (int)e);
+		LOG_ERR("sid init err %d (%s)", (int)e, SID_ERROR_T_STR(e));
 	}
 #ifdef CONFIG_SIDEWALK_FILE_TRANSFER_DFU
 	app_file_transfer_demo_init(sid->handle);
 #endif
 	e = sid_start(sid->handle, sid->config.link_mask);
 	if (e) {
-		LOG_ERR("sid start err %d", (int)e);
+		LOG_ERR("sid start err %d (%s)", (int)e, SID_ERROR_T_STR(e));
 	}
 #if CONFIG_SID_END_DEVICE_AUTO_CONN_REQ
 	if (sid->config.link_mask & SID_LINK_TYPE_1) {
@@ -314,7 +315,8 @@ void sidewalk_event_link_switch(sidewalk_ctx_t *sid, void *ctx)
 		e = sid_option(sid->handle, SID_OPTION_SET_LINK_CONNECTION_POLICY, &set_policy,
 			       sizeof(set_policy));
 		if (e) {
-			LOG_ERR("sid option multi link manager err %d", (int)e);
+			LOG_ERR("sid option multi link manager err %d (%s)", (int)e,
+				SID_ERROR_T_STR(e));
 		}
 
 		struct sid_link_auto_connect_params ac_params = {
@@ -327,7 +329,8 @@ void sidewalk_event_link_switch(sidewalk_ctx_t *sid, void *ctx)
 		e = sid_option(sid->handle, SID_OPTION_SET_LINK_POLICY_AUTO_CONNECT_PARAMS,
 			       &ac_params, sizeof(ac_params));
 		if (e) {
-			LOG_ERR("sid option multi link policy err %d", (int)e);
+			LOG_ERR("sid option multi link policy err %d (%s)", (int)e,
+				SID_ERROR_T_STR(e));
 		}
 	}
 #endif /* CONFIG_SID_END_DEVICE_AUTO_CONN_REQ */

--- a/subsys/sal/sid_pal/src/pal_init.c
+++ b/subsys/sal/sid_pal/src/pal_init.c
@@ -20,6 +20,7 @@
 #include <sid_pal_storage_kv_ifc.h>
 #include <sid_pal_mfg_store_ifc.h>
 #include <sid_pal_temperature_ifc.h>
+#include <json_printer/sidTypes2str.h>
 
 LOG_MODULE_REGISTER(sid_board_init, CONFIG_SIDEWALK_LOG_LEVEL);
 
@@ -32,19 +33,22 @@ sid_error_t application_pal_init(void)
 
 	ret_code = sid_pal_storage_kv_init();
 	if (ret_code) {
-		LOG_ERR("Sidewalk KV store init failed, err: %d", ret_code);
+		LOG_ERR("Sidewalk KV store init failed, err: %d (%s)", ret_code,
+			SID_ERROR_T_STR(ret_code));
 		return ret_code;
 	}
 
 	ret_code = sid_pal_crypto_init();
 	if (ret_code) {
-		LOG_ERR("Sidewalk Init Crypto HAL, err: %d", ret_code);
+		LOG_ERR("Sidewalk Init Crypto HAL, err: %d (%s)", ret_code,
+			SID_ERROR_T_STR(ret_code));
 		return ret_code;
 	}
 #if defined(CONFIG_SIDEWALK_TEMPERATURE)
 	ret_code = sid_pal_temperature_init();
 	if (ret_code) {
-		LOG_ERR("Sidewalk Init temperature pal  err: %d", ret_code);
+		LOG_ERR("Sidewalk Init temperature pal  err: %d (%s)", ret_code,
+			SID_ERROR_T_STR(ret_code));
 	}
 #endif
 	static const sid_pal_mfg_store_region_t mfg_store_region = {


### PR DESCRIPTION
It may be confusing if an error value is erno or sid_error_t. All logs with sid_error_t have their string representation in logs now.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
