### PR TITLE
pal: spi: Move CS pin control to SPI driver.

### DIFF
--- a/samples/sid_end_device/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sid_end_device/boards/nrf52840dk_nrf52840.overlay
@@ -9,8 +9,9 @@
 };
 
 sid_semtech: &spi2 {
-	compatible = "nordic,nrf-spim";
 	status = "okay";
+	cs-gpios = <&gpio1 0x8 GPIO_ACTIVE_LOW>;
+	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-1 = <&spi2_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -51,10 +52,6 @@ sid_semtech: &spi2 {
 
 	semtech_sx1262_gpios{
 		compatible = "gpio-keys";
-		semtech_sx1262_cs: cs {
-			gpios = <&gpio1 0x8 GPIO_ACTIVE_LOW>;
-			label = "semtech_sx1262 CS";
-		};
 		semtech_sx1262_reset_gpios: reset {
 			gpios = <&gpio0 0x3 GPIO_ACTIVE_LOW>;
 			label = "semtech_sx1262 Reset";

--- a/samples/sid_end_device/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/sid_end_device/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,8 +11,9 @@
 };
 
  sid_semtech: &spi4 {
-	compatible = "nordic,nrf-spim";
 	status = "okay";
+	cs-gpios = <&gpio1 0x9 GPIO_ACTIVE_LOW>;
+	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi4_default>;
 	pinctrl-1 = <&spi4_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -53,26 +54,22 @@
 
 	semtech_sx1262_gpios{
 		compatible = "gpio-keys";
-	   semtech_sx1262_cs: cs {
-		   gpios = <&gpio1 0x9 GPIO_ACTIVE_LOW>;
-		   label = "semtech_sx1262 CS";
-	   };
 		semtech_sx1262_reset_gpios: reset {
-		   gpios = <&gpio0 0x4 GPIO_ACTIVE_LOW>;
-		   label = "semtech_sx1262 Reset";
-	   };
-	   semtech_sx1262_busy_gpios: busy {
-		   gpios = <&gpio1 0x5 GPIO_ACTIVE_HIGH>;
-		   label = "semtech_sx1262 Busy";
-	   };
-	   semtech_sx1262_antenna_enable_gpios: antena_enable {
-		   gpios = <&gpio1 0xa GPIO_ACTIVE_HIGH>;
-		   label = "semtech_sx1262 Antena Enable";
-	   };
-	   semtech_sx1262_dio1_gpios: dio1 {
-		   gpios = <&gpio1 0x7 GPIO_ACTIVE_HIGH>;
-		   label = "semtech_sx1262 DIO1";
-	   };
+			gpios = <&gpio0 0x4 GPIO_ACTIVE_LOW>;
+			label = "semtech_sx1262 Reset";
+		};
+		semtech_sx1262_busy_gpios: busy {
+			gpios = <&gpio1 0x5 GPIO_ACTIVE_HIGH>;
+			label = "semtech_sx1262 Busy";
+		};
+		semtech_sx1262_antenna_enable_gpios: antena_enable {
+			gpios = <&gpio1 0xa GPIO_ACTIVE_HIGH>;
+			label = "semtech_sx1262 Antena Enable";
+		};
+		semtech_sx1262_dio1_gpios: dio1 {
+			gpios = <&gpio1 0x7 GPIO_ACTIVE_HIGH>;
+			label = "semtech_sx1262 DIO1";
+		};
 	};
 
 	chosen {

--- a/samples/sid_end_device/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
+++ b/samples/sid_end_device/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
@@ -25,8 +25,9 @@
 };
 
 sid_semtech: &spi00 {
-	compatible = "nordic,nrf-spim";
 	status = "okay";
+	cs-gpios = <&gpio2 0xa GPIO_PULL_UP>;
+	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi00_default>;
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -43,10 +44,6 @@ sid_semtech: &spi00 {
 
 	semtech_sx1262_gpios{
 		compatible = "gpio-keys";
-		semtech_sx1262_cs: cs {
-			gpios = <&gpio2 0xa GPIO_PULL_UP>;
-			label = "semtech_sx1262 CS";
-		};
 		semtech_sx1262_reset_gpios: reset {
 			gpios = <&gpio1 0xb (GPIO_ACTIVE_LOW|GPIO_PULL_UP)>;
 			label = "semtech_sx1262 Reset";

--- a/samples/sid_end_device/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/samples/sid_end_device/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -30,8 +30,9 @@
 };
 
  sid_semtech: &spi21 {
-	compatible = "nordic,nrf-spim";
 	status = "okay";
+	cs-gpios = <&gpio2 0xa GPIO_PULL_UP>;
+	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi21_default>;
 	pinctrl-1 = <&spi21_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -48,10 +49,6 @@
 
 	semtech_sx1262_gpios{
 		compatible = "gpio-keys";
-		semtech_sx1262_cs: cs {
-			gpios = <&gpio2 0xa GPIO_PULL_UP>;
-			label = "semtech_sx1262 CS";
-		};
 		semtech_sx1262_reset_gpios: reset {
 			gpios = <&gpio0 0x2 (GPIO_ACTIVE_LOW|GPIO_PULL_UP)>;
 			label = "semtech_sx1262 Reset";

--- a/subsys/config/common/src/app_subGHz_config.c
+++ b/subsys/config/common/src/app_subGHz_config.c
@@ -145,25 +145,25 @@ static radio_sx126x_device_config_t radio_sx1262_cfg = {
 const radio_sx126x_device_config_t *get_radio_cfg(void)
 {
 	radio_sx1262_cfg.gpio_power =
-		sid_gpio_utils_register_gpio(
-			(struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(DT_NODELABEL(semtech_sx1262_reset_gpios), gpios, INVALID_DT_GPIO));
+		sid_gpio_utils_register_gpio((struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(
+			DT_NODELABEL(semtech_sx1262_reset_gpios), gpios, INVALID_DT_GPIO));
 	radio_sx1262_cfg.gpio_int1 =
-		sid_gpio_utils_register_gpio(
-			(struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(DT_NODELABEL(semtech_sx1262_dio1_gpios), gpios, INVALID_DT_GPIO));
+		sid_gpio_utils_register_gpio((struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(
+			DT_NODELABEL(semtech_sx1262_dio1_gpios), gpios, INVALID_DT_GPIO));
 	radio_sx1262_cfg.gpio_radio_busy =
-		sid_gpio_utils_register_gpio(
-			(struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(DT_NODELABEL(semtech_sx1262_busy_gpios), gpios, INVALID_DT_GPIO));
+		sid_gpio_utils_register_gpio((struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(
+			DT_NODELABEL(semtech_sx1262_busy_gpios), gpios, INVALID_DT_GPIO));
 	radio_sx1262_cfg.gpio_rf_sw_ena =
-		sid_gpio_utils_register_gpio(
-			(struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(DT_NODELABEL(semtech_sx1262_antenna_enable_gpios),
-							      gpios, INVALID_DT_GPIO));
-	radio_sx1262_cfg.bus_selector.client_selector =
-		sid_gpio_utils_register_gpio(
-			(struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(DT_NODELABEL(semtech_sx1262_cs), gpios, INVALID_DT_GPIO));
-	radio_sx1262_cfg.bus_selector.speed_hz = DT_PROP_OR(DT_NODELABEL(sid_semtech), clock_frequency, SPI_FREQUENCY_DEFAULT);
+		sid_gpio_utils_register_gpio((struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(
+			DT_NODELABEL(semtech_sx1262_antenna_enable_gpios), gpios, INVALID_DT_GPIO));
+	radio_sx1262_cfg.gpio_tx_bypass =
+		sid_gpio_utils_register_gpio((struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(
+			DT_NODELABEL(semtech_sx1262_tx_bypass), gpios, INVALID_DT_GPIO));
+	radio_sx1262_cfg.bus_selector.client_selector = sid_gpio_utils_register_gpio(
+		(struct gpio_dt_spec)GPIO_DT_SPEC_GET(DT_NODELABEL(sid_semtech), cs_gpios));
+	radio_sx1262_cfg.bus_selector.speed_hz =
+		DT_PROP_OR(DT_NODELABEL(sid_semtech), clock_frequency, SPI_FREQUENCY_DEFAULT);
 
-	radio_sx1262_cfg.gpio_tx_bypass = sid_gpio_utils_register_gpio(
-			(struct gpio_dt_spec)GPIO_DT_SPEC_GET_OR(DT_NODELABEL(semtech_sx1262_tx_bypass), gpios, INVALID_DT_GPIO));
 	return &radio_sx1262_cfg;
 }
 

--- a/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
+++ b/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
@@ -7,6 +7,7 @@
 #include <zephyr/device.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/devicetree.h>
 
 #include <sid_pal_serial_bus_ifc.h>
 #include <sid_pal_gpio_ifc.h>
@@ -14,6 +15,8 @@
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sid_spi_bus, CONFIG_SPI_BUS_LOG_LEVEL);
+
+#define SPI_NODE DT_NODELABEL(sid_semtech)
 
 #define SPI_OPTIONS                                                                                \
 	(uint16_t)(SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_OP_MODE_MASTER | SPI_FULL_DUPLEX)
@@ -36,7 +39,7 @@ static const struct sid_pal_serial_bus_iface bus_ops = {
 
 static struct bus_serial_ctx_t bus_serial_ctx = {
 	.iface = &bus_ops,
-	.device = DEVICE_DT_GET(DT_NODELABEL(sid_semtech)),
+	.device = DEVICE_DT_GET(SPI_NODE),
 	.cfg = (struct spi_config){ .operation = SPI_OPTIONS },
 };
 
@@ -68,12 +71,8 @@ static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *if
 
 	struct spi_buf_set rx_set = { .buffers = rx_buff, .count = 1 };
 
-	sid_pal_gpio_write(client->client_selector, 0);
-
 	int err = spi_transceive(bus_serial_ctx.device, &bus_serial_ctx.cfg,
 				 ((tx) ? &tx_set : NULL), ((rx) ? &rx_set : NULL));
-
-	sid_pal_gpio_write(client->client_selector, 1);
 
 	sid_error_t ret = SID_ERROR_NONE;
 
@@ -110,5 +109,8 @@ sid_error_t sid_pal_serial_bus_nordic_spi_create(const struct sid_pal_serial_bus
 
 	*iface = &bus_ops;
 	bus_serial_ctx.cfg.frequency = get_radio_cfg()->bus_selector.speed_hz;
+	bus_serial_ctx.cfg.cs.delay = 0;
+	bus_serial_ctx.cfg.cs.gpio = (struct gpio_dt_spec)GPIO_DT_SPEC_GET(SPI_NODE, cs_gpios);
+
 	return SID_ERROR_NONE;
 }


### PR DESCRIPTION
The SPI driver can use directly the CS pin thus the CS does't need to be control manually in `bus_serial_spi_xfer()` anymore.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [ ] Tests were updated (if applicable).
