### PR TITLE
pal: verify if key id is in secure storage

### DIFF
--- a/subsys/sal/sid_pal/src/sid_crypto_keys.c
+++ b/subsys/sal/sid_pal/src/sid_crypto_keys.c
@@ -173,14 +173,23 @@ int sid_crypto_keys_new_generate(psa_key_id_t id, uint8_t *puk, size_t puk_size)
 
 int sid_crypto_keys_buffer_set(psa_key_id_t id, uint8_t *data, size_t size)
 {
+	psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+	psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+	psa_key_id_t *data_id = (psa_key_id_t *)data;
+
 	/* Check arguments */
 	if (PSA_KEY_ID_NULL == id || !data || size < sizeof(psa_key_id_t)) {
 		return -EINVAL;
 	}
 
+	status = psa_get_key_attributes(id, &attributes);
+	psa_reset_key_attributes(&attributes);
+	if (status != PSA_SUCCESS) {
+		return -EACCES;
+	}
+
 	/* Save key id to buffer */
 	memset(data, 0, size);
-	psa_key_id_t *data_id = (psa_key_id_t *)data;
 	*data_id = id;
 	LOG_DBG("key buffer set %d", id);
 

--- a/subsys/sal/sid_pal/src/sid_storage.c
+++ b/subsys/sal/sid_pal/src/sid_storage.c
@@ -144,7 +144,6 @@ sid_error_t sid_pal_storage_kv_record_get(uint16_t group, uint16_t key, void *p_
 	if (SID_CRYPTO_KEYS_ID_IS_SIDEWALK_KEY(key_id)) {
 		int err = sid_crypto_keys_buffer_set(key_id, (uint8_t *)p_data, len);
 		if (err) {
-			LOG_ERR("Failed to read secure key id %d", key_id);
 			return SID_ERROR_STORAGE_READ_FAIL;
 		} else {
 			return SID_ERROR_NONE;

--- a/tests/functional/crypto_keys/src/main.c
+++ b/tests/functional/crypto_keys/src/main.c
@@ -79,13 +79,18 @@ ZTEST(crypto_keys, test_sid_crypto_key_invalid_args)
 	zassert_equal(-EINVAL, err, "err: %d", err);
 }
 
-ZTEST(crypto_keys, test_sid_crypto_key_buffers)
+ZTEST(crypto_keys, test_sid_crypto_key_import)
 {
+	uint8_t test_key_data[TEST_SYMMETRIC_KEY_SIZE] = { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5,
+							   0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB,
+							   0xAC, 0xAD, 0xAE, 0xAF };
 	psa_key_id_t new_key_id = PSA_KEY_ID_NULL;
-	uint8_t test_key_data[TEST_SYMMETRIC_KEY_SIZE];
 	int err = -ENOEXEC;
 
 	err = sid_crypto_keys_init();
+	zassert_equal(0, err, "err: %d", err);
+
+	err = sid_crypto_keys_new_import(test_key_id, test_key_data, TEST_SYMMETRIC_KEY_SIZE);
 	zassert_equal(0, err, "err: %d", err);
 
 	err = sid_crypto_keys_buffer_set(test_key_id, test_key_data, TEST_SYMMETRIC_KEY_SIZE);
@@ -95,23 +100,6 @@ ZTEST(crypto_keys, test_sid_crypto_key_buffers)
 	zassert_equal(0, err, "err: %d", err);
 
 	zassert_equal(new_key_id, test_key_id);
-
-	err = sid_crypto_keys_deinit();
-	zassert_equal(0, err, "err: %d", err);
-}
-
-ZTEST(crypto_keys, test_sid_crypto_key_import)
-{
-	uint8_t test_key_data[TEST_SYMMETRIC_KEY_SIZE] = { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5,
-							   0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB,
-							   0xAC, 0xAD, 0xAE, 0xAF };
-	int err = -ENOEXEC;
-
-	err = sid_crypto_keys_init();
-	zassert_equal(0, err, "err: %d", err);
-
-	err = sid_crypto_keys_new_import(test_key_id, test_key_data, TEST_SYMMETRIC_KEY_SIZE);
-	zassert_equal(0, err, "err: %d", err);
 
 	err = sid_crypto_keys_delete(test_key_id);
 	zassert_equal(0, err, "err: %d", err);


### PR DESCRIPTION
[KRKNWK-19459]
Check it a persistent key with a given key id
Is present in secure key storage
before setting a key buffer.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).


[KRKNWK-19459]: https://nordicsemi.atlassian.net/browse/KRKNWK-19459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ