### PR TITLE
utils: sidewalk_dfu: align the MCUmgr Bluetooth transport Kconfig

### DIFF
--- a/utils/sidewalk_dfu/Kconfig
+++ b/utils/sidewalk_dfu/Kconfig
@@ -61,8 +61,9 @@ config DFU_UPLOAD_COMPLETE_TIMEOUT
 	  if it do not complete in this time, the device will reboot and exit DFU mode
 
 
-config MCUMGR_TRANSPORT_BT_AUTHEN
-	default n
+choice MCUMGR_TRANSPORT_BT_PERM
+	default MCUMGR_TRANSPORT_BT_PERM_RW
+endchoice
 
 config MCUMGR_TRANSPORT_BT_DYNAMIC_SVC_REGISTRATION
 	default n


### PR DESCRIPTION
Aligned the MCUmgr Bluetooth transport Kconfig with the latest changes from Zephyr.

Ref: [NCSDK-29061]

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: pull/17436/head

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [ ] Change has been tested.
- [x] Tests were updated (if applicable).


[NCSDK-29061]: https://nordicsemi.atlassian.net/browse/NCSDK-29061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ