### PR TITLE
sample: set STATIC_INIT_GNU for the sidewalk sample

### DIFF
--- a/samples/sid_end_device/prj.conf
+++ b/samples/sid_end_device/prj.conf
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+CONFIG_STATIC_INIT_GNU=y
 
 # Sidewalk
 CONFIG_SIDEWALK=y

--- a/samples/sid_end_device/prj_release.conf
+++ b/samples/sid_end_device/prj_release.conf
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+CONFIG_STATIC_INIT_GNU=y
 
 # Sidewalk
 CONFIG_SIDEWALK=y

--- a/tests/manual/simple_bootloader/pm_static_nrf52840dk_nrf52840.yml
+++ b/tests/manual/simple_bootloader/pm_static_nrf52840dk_nrf52840.yml
@@ -1,8 +1,73 @@
+app:
+  address: 0x7200
+  end_address: 0xfd000
+  region: flash_primary
+  size: 0xf5e00
+external_flash:
+  address: 0xf6000
+  end_address: 0x800000
+  region: external_flash
+  size: 0x70a000
 mcuboot:
   address: 0x0
+  end_address: 0x7000
   region: flash_primary
   size: 0x7000
+mcuboot_pad:
+  address: 0x7000
+  end_address: 0x7200
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - mcuboot_primary_app
+  region: flash_primary
+  size: 0x200
+mcuboot_primary:
+  address: 0x7000
+  end_address: 0xfd000
+  orig_span: &id001
+  - app
+  - mcuboot_pad
+  region: flash_primary
+  size: 0xf6000
+  span: *id001
+mcuboot_primary_app:
+  address: 0x7200
+  end_address: 0xfd000
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xf5e00
+  span: *id002
+mcuboot_secondary:
+  address: 0x0
+  device: DT_CHOSEN(nordic_pm_ext_flash)
+  end_address: 0xf6000
+  placement:
+    align:
+      start: 0x4
+  region: external_flash
+  share_size:
+  - mcuboot_primary
+  size: 0xf6000
 mfg_storage:
   address: 0xff000
+  end_address: 0x100000
   region: flash_primary
   size: 0x1000
+settings_storage:
+  address: 0xfd000
+  end_address: 0xff000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x2000
+sram_primary:
+  address: 0x20000000
+  end_address: 0x20040000
+  region: sram_primary
+  size: 0x40000

--- a/tests/manual/simple_bootloader/pm_static_nrf54l15dk_nrf54l15_cpuapp.yml
+++ b/tests/manual/simple_bootloader/pm_static_nrf54l15dk_nrf54l15_cpuapp.yml
@@ -1,18 +1,71 @@
+app:
+  address: 0xc800
+  end_address: 0xc3000
+  region: flash_primary
+  size: 0xb6800
 mcuboot:
   address: 0x0
+  end_address: 0xc000
+  placement:
+    before:
+    - mcuboot_primary
   region: flash_primary
   size: 0xc000
 mcuboot_pad:
   address: 0xc000
   end_address: 0xc800
+  placement:
+    before:
+    - mcuboot_primary_app
   region: flash_primary
   size: 0x800
-app:
-  address: 0xc800
-  end_address: 0x17c000
+mcuboot_primary:
+  address: 0xc000
+  end_address: 0xc3000
+  orig_span: &id001
+  - mcuboot_pad
+  - app
   region: flash_primary
-  size: 0x16f800
+  sharers: 0x1
+  size: 0xb7000
+  span: *id001
+mcuboot_primary_app:
+  address: 0xc800
+  end_address: 0xc3000
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xb6800
+  span: *id002
+mcuboot_secondary:
+  address: 0xc3000
+  end_address: 0x17a000
+  placement:
+    after:
+    - mcuboot_primary
+    align:
+      start: 0x1000
+  region: flash_primary
+  share_size:
+  - mcuboot_primary
+  size: 0xb7000
 mfg_storage:
   address: 0x17c000
+  end_address: 0x17d000
   region: flash_primary
   size: 0x1000
+settings_storage:
+  address: 0x17a000
+  end_address: 0x17c000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x2000
+sram_primary:
+  address: 0x20000000
+  end_address: 0x20040000
+  region: sram_primary
+  size: 0x40000

--- a/tests/manual/simple_bootloader/pm_static_thingy53_nrf5340_cpuapp.yml
+++ b/tests/manual/simple_bootloader/pm_static_thingy53_nrf5340_cpuapp.yml
@@ -35,8 +35,8 @@ mcuboot_primary:
   address: 0x8000
   end_address: 0xfc000
   orig_span: &id001
-  - mcuboot_pad
   - app
+  - mcuboot_pad
   region: flash_primary
   size: 0xf4000
   span: *id001

--- a/tests/unit_tests/pal_crypto/src/main.c
+++ b/tests/unit_tests/pal_crypto/src/main.c
@@ -33,8 +33,6 @@ FAKE_VALUE_FUNC(psa_status_t, psa_mac_sign_setup, psa_mac_operation_t *, mbedtls
 FAKE_VALUE_FUNC(psa_status_t, psa_mac_update, psa_mac_operation_t *, const uint8_t *, size_t);
 FAKE_VALUE_FUNC(psa_status_t, psa_mac_sign_finish, psa_mac_operation_t *, uint8_t *, size_t,
 		size_t *);
-FAKE_VALUE_FUNC(psa_status_t, psa_set_key_domain_parameters, psa_key_attributes_t *, psa_key_type_t,
-		const uint8_t *, size_t);
 FAKE_VALUE_FUNC(psa_status_t, psa_mac_compute, mbedtls_svc_key_id_t, psa_algorithm_t,
 		const uint8_t *, size_t, uint8_t *, size_t, size_t *);
 FAKE_VALUE_FUNC(psa_status_t, psa_cipher_encrypt_setup, psa_cipher_operation_t *,

--- a/tests/unit_tests/sid_dut_shell/mock/shell_mock.h
+++ b/tests/unit_tests/sid_dut_shell/mock/shell_mock.h
@@ -9,5 +9,7 @@
 
 DEFINE_FFF_GLOBALS;
 
-FAKE_VOID_FUNC_VARARG(shell_fprintf_impl, const struct shell *, enum shell_vt100_color,
+FAKE_VOID_FUNC_VARARG(shell_fprintf_info, const struct shell *,
+		      const char *, ...);
+FAKE_VOID_FUNC_VARARG(shell_fprintf_error, const struct shell *,
 		      const char *, ...);

--- a/tests/unit_tests/state_notifier/src/main.c
+++ b/tests/unit_tests/state_notifier/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <ztest_assert.h>
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/utils/include/state_notifier/state_notifier.h
+++ b/utils/include/state_notifier/state_notifier.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <state_notifier/application_states.h>
-#include <autoconf.h> /* for kconfig options */
 
 #define APPLICATION_STATE_ENUM(name) APPLICATION_STATE_##name
 


### PR DESCRIPTION
The sidewalk sample linking places stack_protector from the C library in the init_array sections.

For proper initialization in Zephyr then content in this init_array section requires STATIC_INIT_GNU to be configured.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: pull/16860/head

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [X] There is no commented code.
- [X] There are no TODO/FIXME comments without associated issue ticket.
- [X] Commits are properly organized.
- [X] Change has been tested.
- [ ] Tests were updated (if applicable).
