### PR TITLE
Revert "BLE: clean up registered connection callback"

### DIFF
--- a/subsys/sal/sid_pal/src/sid_ble_connection.c
+++ b/subsys/sal/sid_pal/src/sid_ble_connection.c
@@ -26,7 +26,6 @@ static void ble_mtu_cb(struct bt_conn *conn, uint16_t tx_mtu, uint16_t rx_mtu);
 static sid_ble_conn_params_t conn_params;
 static sid_ble_conn_params_t *p_conn_params_out;
 
-static bool bt_conn_registered = false;
 static struct bt_conn_cb conn_callbacks = {
 	.connected = ble_connect_cb,
 	.disconnected = ble_disconnect_cb,
@@ -104,6 +103,7 @@ const sid_ble_conn_params_t *sid_ble_conn_params_get(void)
 void sid_ble_conn_init(void)
 {
 	p_conn_params_out = &conn_params;
+	static bool bt_conn_registered;
 
 	if (!bt_conn_registered) {
 		int e = bt_conn_cb_register(&conn_callbacks);
@@ -116,14 +116,8 @@ void sid_ble_conn_init(void)
 			return;
 		}
 		}
-		bt_conn_registered = true;
-	} else {
-		LOG_WRN("The connection has already been registered, but init was called again");
-	}
-	static bool gatt_cb_registered = false;
-	if (!gatt_cb_registered) {
-		gatt_cb_registered = true;
 		bt_gatt_cb_register(&gatt_callbacks);
+		bt_conn_registered = true;
 	}
 }
 
@@ -144,15 +138,4 @@ int sid_ble_conn_disconnect(void)
 void sid_ble_conn_deinit(void)
 {
 	p_conn_params_out = NULL;
-	if (bt_conn_registered) {
-		int unregister_result = bt_conn_cb_unregister(&conn_callbacks);
-		switch (unregister_result) {
-		case 0:
-			bt_conn_registered = false;
-			break;
-		default:
-			LOG_ERR("bt_conn_cb_unregister resulted in errno %d = %s",
-				unregister_result, strerror(unregister_result));
-		}
-	}
 }

--- a/tests/unit_tests/sid_ble_connection/src/main.c
+++ b/tests/unit_tests/sid_ble_connection/src/main.c
@@ -19,7 +19,6 @@
 DEFINE_FFF_GLOBALS;
 
 FAKE_VALUE_FUNC(int, bt_conn_cb_register, struct bt_conn_cb *);
-FAKE_VALUE_FUNC(int, bt_conn_cb_unregister, struct bt_conn_cb *);
 FAKE_VOID_FUNC(bt_gatt_cb_register, struct bt_gatt_cb *);
 FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_ref, struct bt_conn *);
 FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
@@ -28,7 +27,6 @@ FAKE_VALUE_FUNC(int, bt_conn_disconnect, struct bt_conn *, uint8_t);
 
 #define FFF_FAKES_LIST(FAKE)                                                                       \
 	FAKE(bt_conn_cb_register)                                                                  \
-	FAKE(bt_conn_cb_unregister)                                                                \
 	FAKE(bt_gatt_cb_register)                                                                  \
 	FAKE(bt_conn_ref)                                                                          \
 	FAKE(bt_conn_unref)                                                                        \
@@ -76,7 +74,6 @@ void test_sid_ble_conn_init(void)
 {
 	sid_ble_conn_init();
 	TEST_ASSERT_EQUAL(1, bt_conn_cb_register_fake.call_count);
-	TEST_ASSERT_EQUAL(0, bt_conn_cb_unregister_fake.call_count);
 	TEST_ASSERT_EQUAL(1, bt_gatt_cb_register_fake.call_count);
 
 	sid_bt_conn_cb = bt_conn_cb_register_fake.arg0_history[0];
@@ -86,8 +83,6 @@ void test_sid_ble_conn_init(void)
 	sid_bt_gatt_cb = bt_gatt_cb_register_fake.arg0_history[0];
 	TEST_ASSERT_NOT_NULL(sid_bt_gatt_cb);
 	TEST_ASSERT_NOT_NULL(sid_bt_gatt_cb->att_mtu_updated);
-	sid_ble_conn_deinit();
-	TEST_ASSERT_EQUAL(1, bt_conn_cb_unregister_fake.call_count);
 }
 
 void test_sid_ble_conn_params_get(void)


### PR DESCRIPTION
This reverts commit ba1964f38cde2e660fcb315b1cf8df66123d257d.

When we unregister disconnection callbacks too early (`sid_ble_conn_deinit`) ble can't be disconnected succesfully.

```
<inf> sid_ble_conn: BT Disconnected Reason: 0x0 = SUCCESS
<inf> sid_cli: sid_deinit returned 0 (SID_ERROR_NONE)
```

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
