### PR TITLE
tests: port assert test to zephyr unit tests

### DIFF
--- a/tests/unit_tests/pal_assert/CMakeLists.txt
+++ b/tests/unit_tests/pal_assert/CMakeLists.txt
@@ -6,12 +6,15 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sidewalk_test_assert)
 
+set(SIDEWALK_BASE $ENV{ZEPHYR_BASE}/../sidewalk)
+# Workaround on build system not able to find this definition (in kernel.h)
+add_definitions(-DARCH_STACK_PTR_ALIGN=8)
 # add test file
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
-
-# generate runner for the test
-test_runner_generate(${app_sources})
+target_include_directories(testbinary PRIVATE ${SIDEWALK_BASE}/subsys/sal/common/sid_pal_ifc)
+target_sources(testbinary PRIVATE 
+    ${SIDEWALK_BASE}/subsys/sal/sid_pal/src/sid_assert.c
+    src/main.c
+)

--- a/tests/unit_tests/pal_assert/Kconfig
+++ b/tests/unit_tests/pal_assert/Kconfig
@@ -3,11 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-config SIDEWALK_BUILD
-	default y
-
-config SIDEWALK_ASSERT
-	default y
-	imply ASSERT
+config SIDEWALK_LOG_LEVEL
+	default 0
 
 source "Kconfig.zephyr"

--- a/tests/unit_tests/pal_assert/prj.conf
+++ b/tests/unit_tests/pal_assert/prj.conf
@@ -3,4 +3,5 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_UNITY=y
+CONFIG_ZTEST=y
+CONFIG_ASSERT=y

--- a/tests/unit_tests/pal_assert/src/main.c
+++ b/tests/unit_tests/pal_assert/src/main.c
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <unity.h>
 #include <sid_pal_assert_ifc.h>
 #include <stdbool.h>
-#include <zephyr/toolchain.h>
+#include <zephyr/ztest.h>
+#include <zephyr/fff.h>
 
-void setUp(void)
+DEFINE_FFF_GLOBALS;
+
+FAKE_VOID_FUNC_VARARG(z_log_minimal_printk, const char *, ...);
+
+static void suite_setup(void *f)
 {
+	RESET_FAKE(z_log_minimal_printk);
 }
 
 /******************************************************************
@@ -24,28 +29,23 @@ void assert_post_action(const char *file, unsigned int line)
 
 	if (should_assert) {
 		should_assert = false;
-		TEST_PASS_MESSAGE("Asserted.");
+		ztest_test_pass();
 	}
-	TEST_FAIL_MESSAGE("Asserted, but should not.");
+	ztest_test_fail();
 }
 
-void test_sid_pal_assert(void)
+ZTEST(assert_tests, test_sid_pal_assert_true)
 {
-	should_assert = false;
-	SID_PAL_ASSERT(true);
-
-	should_assert = true;
-	SID_PAL_ASSERT(false);
-	TEST_ASSERT_FALSE_MESSAGE(should_assert, "No assert when it should be.");
+    should_assert = false;
+    SID_PAL_ASSERT(true);
+    zassert_false(should_assert, "No assert when it should be.");
 }
 
-/* It is required to be added to each test. That is because unity is using
- * different main signature (returns int) and zephyr expects main which does
- * not return value.
- */
-extern int unity_main(void);
-
-int main(void)
+ZTEST(assert_tests, test_sid_pal_assert_false)
 {
-	return unity_main();
+    should_assert = true;
+    SID_PAL_ASSERT(false);
+    zassert_false(should_assert, "Asserted, but should not.");
 }
+
+ZTEST_SUITE(assert_tests, NULL, NULL, suite_setup, NULL, NULL);

--- a/tests/unit_tests/pal_assert/testcase.yaml
+++ b/tests/unit_tests/pal_assert/testcase.yaml
@@ -1,7 +1,5 @@
 tests:
   sidewalk.unit_tests.assert:
-    sysbuild: true
-    platform_allow: native_posix
+    sysbuild: false
     tags: Sidewalk
-    integration_platforms:
-      - native_posix
+    type: unit


### PR DESCRIPTION
Assert tests to use zephyr unit testing framework. It fixes false negative result when the posix board was used.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
