### PR TITLE
cmake: removing manual linking of libgcc.a

### DIFF
--- a/lib/cortex-m33/lora_fsk/CMakeLists.txt
+++ b/lib/cortex-m33/lora_fsk/CMakeLists.txt
@@ -6,11 +6,6 @@
 
 set(SID_LIB_DIR ${ZEPHYR_BASE}/../sidewalk/lib/cortex-m33/lora_fsk)
 
-set(GCC_LIB_DIR ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/lib/gcc/arm-zephyr-eabi)
-find_library(LIB_GCC NAMES gcc libgcc.a HINTS ${GCC_LIB_DIR}/* REQUIRED)
-
-zephyr_library_link_libraries(${SID_LIB_DIR}/libsid_protocol_all.a
-	${LIB_GCC}
-)
+zephyr_library_link_libraries(${SID_LIB_DIR}/libsid_protocol_all.a)
 
 zephyr_link_libraries_ifndef(CONFIG_SIDEWALK_PAL_RADIO_SOURCE ${SID_LIB_DIR}/libsid_pal_radio_sx126x_impl.a)

--- a/lib/cortex-m4/lora_fsk/CMakeLists.txt
+++ b/lib/cortex-m4/lora_fsk/CMakeLists.txt
@@ -6,11 +6,7 @@
 
 set(SID_LIB_DIR ${ZEPHYR_BASE}/../sidewalk/lib/cortex-m4/lora_fsk)
 
-set(GCC_LIB_DIR ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/lib/gcc/arm-zephyr-eabi)
-find_library(LIB_GCC NAMES gcc libgcc.a HINTS ${GCC_LIB_DIR}/* REQUIRED)
 
-zephyr_library_link_libraries(${SID_LIB_DIR}/libsid_protocol_all.a
-	${LIB_GCC}
-)
+zephyr_library_link_libraries(${SID_LIB_DIR}/libsid_protocol_all.a)
 
 zephyr_link_libraries_ifndef(CONFIG_SIDEWALK_PAL_RADIO_SOURCE ${SID_LIB_DIR}/libsid_pal_radio_sx126x_impl.a)


### PR DESCRIPTION
This commit removes the manual lookup and linking of libgcc.a.

Linking of C and runtime libraries are the responsibility of the higher level build system which handles the toolchain and building of the executable.

Current sidewalk implementation is broken in the sense that it fails to consider the CPU architecture and just looks up any libgcc.a file.

For example the code might discover `arm-zephyr-eabi/12.2.0/libgcc.a` when instead `arm-zephyr-eabi/12.2.0/thumb/v8-m.main+fp/hard/libgcc.a` should be used, and thus causiong link errors such as:
> error: /.../12.2.0/libgcc.a(_arm_muldf3.o):
>                                    conflicting CPU architectures 17/2

and:
> error: zephyr/zephyr_pre0.elf uses VFP register arguments,
>        /.../12.2.0/libgcc.a(_fixunsdfdi.o) does not
