### PR TITLE
ble: Remove CONFIG_BT_BUF_ACL_RX_COUNT

### DIFF
--- a/samples/sid_end_device/Kconfig.defconfig
+++ b/samples/sid_end_device/Kconfig.defconfig
@@ -17,8 +17,8 @@ config BT_BUF_ACL_TX_COUNT
 config BT_BUF_ACL_RX_SIZE
 	default 251
 
-config BT_BUF_ACL_RX_COUNT
-	default 6
+config BT_BUF_ACL_RX_COUNT_EXTRA
+	default 4
 
 config BT_L2CAP_TX_MTU
 	default 247


### PR DESCRIPTION
CONFIG_BT_BUF_ACL_RX_COUNT has been deprecated in
https://github.com/zephyrproject-rtos/zephyr/pull/81747 CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA has been introduced to replace it.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: pull/19412/head

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
