### PR TITLE
log: disable RTT backend when SHELL is in use.

### DIFF
--- a/samples/sid_end_device/Kconfig
+++ b/samples/sid_end_device/Kconfig
@@ -58,9 +58,6 @@ config SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE
 config SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE
 	default 1024
 
-config LOG_PROCESS_THREAD_STARTUP_DELAY_MS
-	default 100
-
 endif # SID_END_DEVICE_CLI
 
 config SID_END_DEVICE_AUTO_START
@@ -172,5 +169,15 @@ config PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER
 	default n if SOC_NRF52840 || SOC_NRF5340_CPUAPP
 
 endif #SIDEWALK_CRYPTO
+
+if SHELL
+# TODO: Remove when merged in NCS copy of sdk-zephyr https://github.com/zephyrproject-rtos/zephyr/pull/85790
+# Workaround for missing first few logs.
+    config LOG_BACKEND_RTT
+        bool "Segger J-Link RTT backend"
+        depends on USE_SEGGER_RTT
+        default y if !SHELL_LOG_BACKEND
+        default n
+endif #SHELL
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
Logs are sent only to backends that are ready,
If some backend like SHELL takes some time to start, and other backend is already initialized.
The messages will not be sent to the uninitialled backend. The solution is to disable the unused backend
and therefore the logs will wait for the shell to initialize


## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: KRKNWK-20023

## Self review

- [x] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
