### PR TITLE
utils: add state notifier disable option

### DIFF
--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -10,14 +10,14 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
-  integration_platforms:
-    - nrf52840dk/nrf52840
-    - nrf5340dk/nrf5340/cpuapp
-    - nrf54l15dk/nrf54l15/cpuapp
-    - nrf54l15dk/nrf54l15/cpuapp/ns
-    - nrf54l15dk/nrf54l10/cpuapp
 tests:
   sample.sidewalk.hello:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_configs:
       - CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK=y
       - CONFIG_SIDEWALK_FILE_TRANSFER=y
@@ -27,6 +27,12 @@ tests:
       - hello
 
   sample.sidewalk.hello.release:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK=y
@@ -36,6 +42,12 @@ tests:
       - hello
 
   sample.sidewalk.hello.ble_only:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_configs:
       - CONFIG_SIDEWALK_SUBGHZ_SUPPORT=n
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.ble_only"
@@ -45,6 +57,12 @@ tests:
       - BLE
 
   sample.sidewalk.hello.ble_only.release:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_SIDEWALK_SUBGHZ_SUPPORT=n
@@ -55,6 +73,12 @@ tests:
       - BLE
 
   sample.sidewalk.demo:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-demo.conf"
     extra_configs:
       - CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK=y
@@ -78,6 +102,12 @@ tests:
       - BLE
 
   sample.sidewalk.dut:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-dut.conf"
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="dut"
@@ -86,6 +116,12 @@ tests:
       - cli
 
   sample.sidewalk.dut.ble_only:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-dut.conf"
     extra_configs:
       - CONFIG_SIDEWALK_SUBGHZ_SUPPORT=n
@@ -96,6 +132,12 @@ tests:
       - BLE
 
   sample.sidewalk.dut.no_secure:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-dut.conf"
     extra_configs:
       - CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE=n
@@ -104,3 +146,64 @@ tests:
       - Sidewalk
       - cli
       - no_secure
+
+  sample.sidewalk.helloPower.ble.release:
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    extra_args: FILE_SUFFIX=release
+    extra_configs:
+      - CONFIG_STATE_NOTIFIER=n
+      - CONFIG_SIDEWALK_LINK_MASK_BLE=y
+      - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.release.ble"
+    tags:
+      - Sidewalk
+      - helloPower
+
+  sample.sidewalk.helloPower.fsk.release:
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    extra_args: FILE_SUFFIX=release
+    extra_configs:
+      - CONFIG_STATE_NOTIFIER=n
+      - CONFIG_SIDEWALK_LINK_MASK_FSK=y
+      - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.release.fsk"
+    tags:
+      - Sidewalk
+      - helloPower
+
+  sample.sidewalk.helloPower.lora.release:
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    extra_args: FILE_SUFFIX=release
+    extra_configs:
+      - CONFIG_STATE_NOTIFIER=n
+      - CONFIG_SIDEWALK_LINK_MASK_LORA=y
+      - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.release.lora"
+    tags:
+      - Sidewalk
+      - helloPower
+
+  sample.sidewalk.helloPower.ble_only.release:
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    extra_args: FILE_SUFFIX=release
+    extra_configs:
+      - CONFIG_STATE_NOTIFIER=n
+      - CONFIG_SIDEWALK_SUBGHZ_SUPPORT=n
+      - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.ble_only.release"
+    tags:
+      - Sidewalk
+      - helloPower
+      - BLE

--- a/utils/include/state_notifier/state_notifier.h
+++ b/utils/include/state_notifier/state_notifier.h
@@ -29,6 +29,12 @@ struct notifier_state {
 };
 #undef X
 
+#if defined(CONFIG_STATE_NOTIFIER_HANDLER_MAX) && (CONFIG_STATE_NOTIFIER_HANDLER_MAX > 0)
+#define HANDLES_NO (CONFIG_STATE_NOTIFIER_HANDLER_MAX)
+#else
+#define HANDLES_NO (1)
+#endif /* CONFIG_STATE_NOTIFIER_HANDLER_MAX */
+
 /**
  * @brief Array holding the string representations of the state names
  */
@@ -74,7 +80,7 @@ typedef void (*state_change_handler)(const struct notifier_state *new_state);
  */
 struct notifier_ctx {
 	struct notifier_state app_state;
-	state_change_handler handler[CONFIG_STATE_NOTIFIER_HANDLER_MAX];
+	state_change_handler handler[HANDLES_NO];
 };
 
 #define X(name, ...) void application_state_##name(struct notifier_ctx *ctx, const uint32_t value);

--- a/utils/sidewalk_dfu/nordic_dfu.c
+++ b/utils/sidewalk_dfu/nordic_dfu.c
@@ -218,8 +218,9 @@ static void pending_adv_start(struct k_work *work)
 int nordic_dfu_ble_start(void)
 {
 	LOG_INF("Entering into DFU mode");
-
+#if defined(CONFIG_STATE_NOTIFIER)
 	application_state_dfu(&global_state_notifier, true);
+#endif
 	dk_leds_init();
 
 	int err = sid_ble_bt_enable(NULL);
@@ -295,8 +296,9 @@ int nordic_dfu_ble_stop(void)
 
 	k_timer_stop(&led_timer);
 	k_timer_stop(&exit_timer);
-
+#if defined(CONFIG_STATE_NOTIFIER)
 	application_state_dfu(&global_state_notifier, false);
+#endif
 
 	return 0;
 }

--- a/utils/state_notifier/Kconfig
+++ b/utils/state_notifier/Kconfig
@@ -5,7 +5,7 @@
 #
 
 config STATE_NOTIFIER
-	bool 
+	bool "Sidewalk state notifier"
 	default SIDEWALK
 	help
 	  Stete notifier module for Sidewalk application.


### PR DESCRIPTION
Add switch to disable state notifier
Add ifdefs in application code

west build -b nrf54l15dk/nrf54l15/cpuapp -p -T ./sample.sidewalk.hello.release -- -DCONFIG_STATE_NOTIFIER=n

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
