### PR TITLE
samples: Set only lora on CONFIG_SIDEWALK_LINK_MASK_LORA

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -36,19 +36,19 @@ config SIDEWALK_PAL_RADIO_SOURCE
 endif # SIDEWALK_SUBGHZ_SUPPORT
 
 choice SIDEWALK_LINK_MASK
-	prompt "Physical link type [DEPRICATED]"
+	prompt "Physical link type"
 	default SIDEWALK_LINK_MASK_BLE
 	help
-	  Select the physical link type for Sidewalk connection.
+	  Choose the default physical link type for Sidewalk connection.
 
 config SIDEWALK_LINK_MASK_BLE
-	bool "Bluetooth Low Energy link [DEPRICATED]"
+	bool "Bluetooth Low Energy link"
 
 config SIDEWALK_LINK_MASK_FSK
-	bool "Sub-GHz link for FSK [DEPRICATED]"
+	bool "Sub-GHz link for FSK"
 
 config SIDEWALK_LINK_MASK_LORA
-	bool "Sub-GHz link for LORA [DEPRICATED]"
+	bool "Sub-GHz link for LORA"
 
 endchoice # SIDEWALK_LINK_MASK
 

--- a/doc/includes/include_kconfig_common.txt
+++ b/doc/includes/include_kconfig_common.txt
@@ -21,13 +21,21 @@
 
 * ``CONFIG_SIDEWALK_ON_DEV_CERT`` -- Enables the on-device certification Shell.
 
-* ``SIDEWALK_CRYPTO_PSA_KEY_STORAGE`` - Enables secure storage for persistent Sidewalk keys.
+* ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE`` - Enables secure storage for persistent Sidewalk keys.
 
-* ``SIDEWALK_MFG_STORAGE_SUPPORT_HEX_v7`` - Enables support for Sidewalk manufacturing HEX in version 7 and below.
+* ``CONFIG_SIDEWALK_MFG_STORAGE_SUPPORT_HEX_v7`` - Enables support for Sidewalk manufacturing HEX in version 7 and below.
 
 * ``CONFIG_SID_END_DEVICE_AUTO_START`` -- Enables an automatic Sidewalk initialization and start.
 
 * ``CONFIG_SID_END_DEVICE_AUTO_CONN_REQ`` -- Enables an automatic connection request before sending a message.
   If needed, the Bluetooth LE connection request is sent automatically.
 
-* ``SID_END_DEVICE_PERSISTENT_LINK_MASK`` - Enables persistent link mask.
+* ``CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK`` - Enables persistent link mask.
+
+* ``CONFIG_SIDEWALK_LINK_MASK`` - Choose the default physical link type for Sidewalk connection to start with
+
+   * ``CONFIG_SIDEWALK_LINK_MASK_BLE`` -- Choose Bluetooth Low Energy link.
+
+   * ``CONFIG_SIDEWALK_LINK_MASK_FSK`` -- Choose Sub-GHz link for FSK.
+
+   * ``CONFIG_SIDEWALK_LINK_MASK_LORA`` -- Choose Sub-GHz link for LORA.

--- a/samples/sid_end_device/include/sidewalk.h
+++ b/samples/sid_end_device/include/sidewalk.h
@@ -53,7 +53,7 @@ int sidewalk_event_send(event_handler_t event, void *ctx, ctx_free free);
 #elif CONFIG_SIDEWALK_LINK_MASK_FSK
 #define DEFAULT_LM (uint32_t)(SID_LINK_TYPE_2)
 #elif CONFIG_SIDEWALK_LINK_MASK_LORA
-#define DEFAULT_LM (uint32_t)(SID_LINK_TYPE_1 | SID_LINK_TYPE_3)
+#define DEFAULT_LM (uint32_t)(SID_LINK_TYPE_3)
 #else
 #define DEFAULT_LM (uint32_t)(SID_LINK_TYPE_1)
 #endif


### PR DESCRIPTION
- Set CONFIG_SIDEWALK_LINK_MASK_LORA to LINK_TYPE_3
- Removed deprecated labels from physical link type prompts in Kconfig.
- Updated documentation to reflect the new configuration options for link types.

## CI parameters

```yaml
Github_actions:
  #(branch, hash, pull/XXX/head)
  NRF_revision: main

  # Do not change after creating PR
  Create_NRF_PR: false
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
