### PR TITLE
pal: fix misspelled Kconfig in CMakeLists.txt

### DIFF
--- a/subsys/sal/sid_pal/src/CMakeLists.txt
+++ b/subsys/sal/sid_pal/src/CMakeLists.txt
@@ -71,6 +71,6 @@ endif() # CONFIG_SOC_NRF52840
 
 zephyr_library_sources_ifdef(CONFIG_SIDEWALK sid_common.c)
 
-zephyr_library_sources_ifdef(DEPRECATED_SIDEWALK_PAL_INIT pal_init.c)
+zephyr_library_sources_ifdef(CONFIG_DEPRECATED_SIDEWALK_PAL_INIT pal_init.c)
 
 zephyr_library_sources(bt_app_callbacks.c)


### PR DESCRIPTION
Add missing CONFIG_ prefix to CONFIG_DEPRECATED_SIDEWALK_PAL_INIT Kconfig to *actually* allow the use of the deprecated pal_init.c file.

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
