### PR TITLE
GHA: fix issue with GHA scripts

### DIFF
--- a/.github/workflows/nrf-upmerge-pr.yml
+++ b/.github/workflows/nrf-upmerge-pr.yml
@@ -31,6 +31,9 @@ jobs:
           PR_TITLE="manifest: Update NRF"
           PR_BODY="Automated weekly update PR created by GitHub Actions"
 
+          cd sidewalk
+          git fetch --all
+
           # Check if PR branch exists
           if git show-ref --verify --quiet refs/heads/$BRANCH_NAME; then
             echo "Branch $BRANCH_NAME exists, checking PR status..."
@@ -66,9 +69,9 @@ jobs:
           fi
 
           # Run your update script here
-          python3 -m pip install -r sidewalk/scripts/ci/requirements.txt
-          nrf_hash="$(git -C nrf rev-parse HEAD)"
-          python3 sidewalk/scripts/ci/replace_nrf_revision_in_west.py -r $nrf_hash sidewalk/west.yml
+          python3 -m pip install -r scripts/ci/requirements.txt
+          nrf_hash="$(git -C ../nrf rev-parse HEAD)"
+          python3 scripts/ci/replace_nrf_revision_in_west.py -r $nrf_hash west.yml
 
           # Check if there are changes to commit
           if git status --porcelain | grep -q '^[MADRCU]'; then


### PR DESCRIPTION
some scripts can trigger only on main,
so smoe errors needed tobe fixed once merged.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
