### PR TITLE
log: improve logging functionality in sid_log.c

### DIFF
--- a/Kconfig.dependencies
+++ b/Kconfig.dependencies
@@ -253,7 +253,6 @@ endif # SIDEWALK_CRITICAL_REGION
 config SIDEWALK_GPIO
 	bool
 	default SIDEWALK_SUBGHZ_SUPPORT
-	imply SIDEWALK_LOG
 	help
 	  Sidewalk GPIO module
 

--- a/subsys/sal/sid_pal/src/sid_log.c
+++ b/subsys/sal/sid_pal/src/sid_log.c
@@ -10,6 +10,7 @@
 
 #include <sid_pal_log_ifc.h>
 #include <stddef.h>
+#include <stdio.h>
 
 #include <zephyr/sys/printk.h>
 #include <zephyr/logging/log.h>
@@ -21,40 +22,38 @@ LOG_MODULE_REGISTER(sidewalk, CONFIG_SIDEWALK_LOG_LEVEL);
 
 #define MSG_LENGTH_MAX (CONFIG_SIDEWALK_LOG_MSG_LENGTH_MAX)
 
-#if CONFIG_LOG
-#define LOG_VALIST(_level, fmt, valist)                                                            \
-	do {                                                                                       \
-		LOG_RAW("%c: ", z_log_minimal_level_to_char(_level));                              \
-		z_log_vprintk(fmt, valist);                                                        \
-		LOG_RAW("\n");                                                                     \
-	} while (false)
-#else
-#define LOG_VALIST(_level, fmt, valist)
-#endif
-
 void sid_pal_log(sid_pal_log_severity_t severity, uint32_t num_args, const char *fmt, ...)
 {
 	ARG_UNUSED(num_args);
 
+#if !defined(CONFIG_LOG)
+	ARG_UNUSED(severity);
+	ARG_UNUSED(fmt);
+	return;
+#endif /* !defined(CONFIG_LOG) */
+
 	va_list args;
 	va_start(args, fmt);
 
+	char buf[MSG_LENGTH_MAX];
+	vsnprintf(buf, sizeof(buf), fmt, args);
+
 	switch (severity) {
 	case SID_PAL_LOG_SEVERITY_ERROR:
-		LOG_VALIST(LOG_LEVEL_ERR, fmt, args);
+		LOG_ERR("%s", buf);
 		break;
 	case SID_PAL_LOG_SEVERITY_WARNING:
-		LOG_VALIST(LOG_LEVEL_WRN, fmt, args);
+		LOG_WRN("%s", buf);
 		break;
 	case SID_PAL_LOG_SEVERITY_INFO:
-		LOG_VALIST(LOG_LEVEL_INF, fmt, args);
+		LOG_INF("%s", buf);
 		break;
 	case SID_PAL_LOG_SEVERITY_DEBUG:
-		LOG_VALIST(LOG_LEVEL_DBG, fmt, args);
+		LOG_DBG("%s", buf);
 		break;
 	default:
-		LOG_VALIST(LOG_LEVEL_DBG, fmt, args);
-		LOG_WRN("sid pal log unknow severity %d", severity);
+		LOG_DBG("%s", buf);
+		LOG_WRN("sid pal log unknown severity %d", severity);
 		break;
 	}
 

--- a/tests/integration/spi/Kconfig
+++ b/tests/integration/spi/Kconfig
@@ -27,7 +27,7 @@ config SIDEWALK_GPIO
 	default y
 
 config SIDEWALK_GPIO_MAX
-    default 6
+	default 6
 
 config SIDEWALK_GPIO_IRQ_PRIORITY
 	default 1


### PR DESCRIPTION
Replace LOG_VALIST macro with direct logging calls for different severities.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
