### PR TITLE
config: add TCXO control via DIO3

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -29,6 +29,12 @@ config SIDEWALK_SUBGHZ_TRIM_CAP_VAL
 	help
 	  The value of the trim cap. Default value works for Semtech SX1262 shield.
 
+config SIDEWALK_SUBGHZ_TCXO_CTRL_DIO3
+	bool "Enable TCXO control via DIO3 for SX1262 [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  Enable TCXO control via DIO3 for SX1262.
+
 endif # SIDEWALK_SUBGHZ_SUPPORT
 
 choice SIDEWALK_LINK_MASK

--- a/subsys/config/common/src/app_subGHz_config.c
+++ b/subsys/config/common/src/app_subGHz_config.c
@@ -119,8 +119,14 @@ static radio_sx126x_device_config_t radio_sx1262_cfg = {
 	.pa_cfg_callback = radio_sx1262_pa_cfg,
 
 	.tcxo = {
-        	.ctrl = SX126X_TCXO_CTRL_NONE,
-    	},
+#if defined(CONFIG_SIDEWALK_SUBGHZ_TCXO_CTRL_DIO3)
+		.ctrl = SX126X_TCXO_CTRL_DIO3,
+		.voltage = RADIO_SX126X_TCXO_CTRL_1_8V,
+		.timeout = 10,
+#else
+		.ctrl = SX126X_TCXO_CTRL_NONE,
+#endif /* CONFIG_SIDEWALK_SUBGHZ_TCXO_CTRL_DIO3 */
+	},
 
 	.trim_cap_val_callback = radio_sx1262_trim_val,
 


### PR DESCRIPTION
[KRKNWK-19841]
Add pin control for tcxo in SX1262 config.
For more details see radio_sx126x_tcxo_t from
subsys/semtech/sx126x/include/sx126x_config.h

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).


[KRKNWK-19841]: https://nordicsemi.atlassian.net/browse/KRKNWK-19841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ