### PR TITLE
config: Fix order of default SPI IDX assignment

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -213,9 +213,9 @@ endchoice # SIDEWALK_NRFX_SPI_INSTANCE_ID
 config SIDEWALK_NRFX_SPI_ID
 	int
 	depends on SOC_NRF52840
-	default 2
-	default 1 if SIDEWALK_NRFX_SPI1
 	default 0 if SIDEWALK_NRFX_SPI0
+	default 1 if SIDEWALK_NRFX_SPI1
+	default 2
 
 endif # SIDEWALK_SPI_BUS
 


### PR DESCRIPTION
Fixes issue where the incorrect SPI IDX would be set when trying to use another bus

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [ ] Tests were updated (if applicable).
