### PR TITLE
subsys: config: common: Add extern "C" to ble and subGHz config

### DIFF
--- a/subsys/config/common/include/app_ble_config.h
+++ b/subsys/config/common/include/app_ble_config.h
@@ -18,6 +18,14 @@
 
 #include <sid_ble_link_config_ifc.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 const sid_ble_link_config_t* app_get_ble_config(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //APP_BLE_CONFIG_H

--- a/subsys/config/common/include/app_subGHz_config.h
+++ b/subsys/config/common/include/app_subGHz_config.h
@@ -20,7 +20,16 @@
 #include <sid_pal_mfg_store_ifc.h>
 #include <sid_900_cfg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 const radio_sx126x_device_config_t* get_radio_cfg(void);
 const sid_pal_mfg_store_region_t* get_mfg_cfg(void);
 struct sid_sub_ghz_links_config* app_get_sub_ghz_config(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif


### PR DESCRIPTION
In cpp projects, these headers cannot be found by the linker because of missing `extern "C" { }` guards. This commit addresses that by adding it to both config headers

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
