### PR TITLE
sal: sid_pal: add support for cpp linker

### DIFF
--- a/subsys/sal/sid_pal/include/bt_app_callbacks.h
+++ b/subsys/sal/sid_pal/include/bt_app_callbacks.h
@@ -11,6 +11,10 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief check if attr is for SMP service
  * 
@@ -63,5 +67,9 @@ enum sid_ble_id_values {
 #if defined(CONFIG_BT_ID_MAX)
 BUILD_ASSERT(_BT_ID_MAX <= CONFIG_BT_ID_MAX,
 	     "Too many BT Ids! increase CONFIG_BT_ID_MAX, to match _BT_ID_MAX");
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 #endif

--- a/utils/include/settings_utils.h
+++ b/utils/include/settings_utils.h
@@ -10,6 +10,10 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(DEPRECATED_DFU_FLAG_SETTINGS_KEY)
 typedef enum { DFU_APPLICATION, SIDEWALK_APPLICATION } app_start_t;
 app_start_t application_to_start(void);
@@ -52,5 +56,9 @@ int settings_utils_get_value_size(const char *name, size_t *len);
  * @return int number of readed bytes or negative errno on fail.
  */
 int settings_utils_load_immediate_value(const char *name, void *dest, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SETTINGS_UTILS_H */


### PR DESCRIPTION
adds `extern "C"` guards to bt_app_callbacks header for cpp support

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [X] There is no commented code.
- [X] There are no TODO/FIXME comments without associated issue ticket.
- [X] Commits are properly organized.
- [X] Change has been tested.
- [X] Tests were updated (if applicable).
