### PR TITLE
Fix sid ble option fault 

### DIFF
--- a/doc/known_issues.rst
+++ b/doc/known_issues.rst
@@ -73,6 +73,11 @@ KRKNWK-21160: Semtech interrupt pin remains high blocking the Wi-Fi scan.
 
   **Workaround:** Clear event pin interrupt in Semtech hal after each occurrence.
 
+KRKNWK-21514: Sidewalk option for Bluetooth LE config (``SID_OPTION_BLE_USER_CONFIG``) is not supported in the NCS
+  Calling the Sidewalk Kconfig option ``SID_OPTION_BLE_USER_CONFIG`` causes the application to crash.
+
+  **Affected platforms:** All platforms.
+
 List of known issues for v1.0.1
 *******************************
 

--- a/samples/sid_end_device/include/cli/app_shell.h
+++ b/samples/sid_end_device/include/cli/app_shell.h
@@ -229,6 +229,13 @@
 #define CMD_SID_SET_OPTION_LP_SET_ARG_OPTIONAL 1
 #define CMD_SID_OPTION_GSI_ARG_REQUIRED 1
 #define CMD_SID_OPTION_GSI_ARG_OPTIONAL 0
+#define CMD_SID_OPTION_BLE_CFG_DESCRIPTION                                                       \
+	"set <cfg_type> [inactivity_timeout]\n"                                                   \
+	"Set BLE user config (SID_OPTION_BLE_USER_CONFIG).\n"                                     \
+	"<cfg_type> 0=ADV, 1=CONN, 2=ADV_AND_CONN, 3=INACTIVITY_TIMEOUT.\n"                       \
+	"For cfg_type 3, <inactivity_timeout> (seconds) is required."
+#define CMD_SID_OPTION_BLE_CFG_ARG_REQUIRED 2
+#define CMD_SID_OPTION_BLE_CFG_ARG_OPTIONAL 1
 #define CMD_SID_LAST_STATUS_ARG_REQUIRED 1
 #define CMD_SID_LAST_STATUS_ARG_OPTIONAL 0
 #define CMD_SID_CONN_REQUEST_ARG_REQUIRED 2
@@ -271,6 +278,7 @@ int cmd_sid_option_c(const struct shell *shell, int32_t argc, const char **argv)
 int cmd_sid_option_ml(const struct shell *shell, int32_t argc, const char **argv);
 int cmd_sid_option_gc(const struct shell *shell, int32_t argc, const char **argv);
 int cmd_sid_option_sid_id(const struct shell *shell, int32_t argc, const char **argv);
+int cmd_sid_option_ble_cfg_set(const struct shell *shell, int32_t argc, const char **argv);
 
 int cmd_sid_last_status(const struct shell *shell, int32_t argc, const char **argv);
 int cmd_sid_conn_request(const struct shell *shell, int32_t argc, const char **argv);

--- a/subsys/sal/sid_pal/include/bt_app_callbacks.h
+++ b/subsys/sal/sid_pal/include/bt_app_callbacks.h
@@ -44,16 +44,18 @@ int sid_ble_bt_enable(bt_ready_cb_t cb);
 
 /**
  * @brief Wrapper for @bt_disable.
- * This function removes internal reference.
- * If the internal reference counter shows 0, real @bt_disable is called
- * 
- * @return int result from @bt_disable or 0 if sid_ble_bt_enable has been called more than sid_ble_bt_disable
+ * This function removes an internal reference. 
+ * If the internal reference counter reaches 0, the real @bt_disable is called.
+ *
+ * @return int 0 on successful disable,
+ *        Negative error codes as returned by @bt_disable,
+ *        Positive number indicating the number of connections left.
  */
 int sid_ble_bt_disable();
 
 /**
  * @brief BT ids used for extended advertising. 
- * This allows to identify connections from different extended adverticements.
+ * This allows to identify connections from different extended advertisements.
  */
 enum sid_ble_id_values {
 	_BT_ID_DEFAULT = BT_ID_DEFAULT,

--- a/subsys/sal/sid_pal/src/bt_app_callbacks.c
+++ b/subsys/sal/sid_pal/src/bt_app_callbacks.c
@@ -42,7 +42,7 @@ int sid_ble_bt_disable()
 		return bt_disable();
 	} else {
 		bt_enable_count--;
-		return 0;
+		return bt_enable_count;
 	}
 }
 

--- a/subsys/sal/sid_pal/src/sid_ble_adapter.c
+++ b/subsys/sal/sid_pal/src/sid_ble_adapter.c
@@ -441,11 +441,13 @@ static sid_error_t ble_adapter_deinit(void)
 	sid_ble_advert_deinit();
 	bt_id_delete(BT_ID_SIDEWALK);
 	bt_id_reset(BT_ID_SIDEWALK, NULL, NULL);
-	int err = sid_ble_bt_disable();
+	int ret = sid_ble_bt_disable();
 
-	if (err) {
-		LOG_ERR("BT disable failed (error %d)", err);
+	if (ret < 0) {
+		LOG_ERR("BT disable failed (error %d)", ret);
 		return SID_ERROR_GENERIC;
+	} else if (ret > 0) {
+		LOG_WRN("Sidewalk ble adapter disabled, but BT still enabled (ret=%d)", ret);
 	}
 
 	return SID_ERROR_NONE;

--- a/tests/unit_tests/sid_dut_shell/Kconfig
+++ b/tests/unit_tests/sid_dut_shell/Kconfig
@@ -14,7 +14,27 @@ config SIDEWALK_LOG_LEVEL
 
 
 config SBDT_MAX_PARALEL_TRANSFERS
-	int 
+	int
 	default 3
+
+config SIDEWALK_BLE_ADV_INT_FAST
+	int "Fast advertise interval in ms"
+	default 160
+
+config SIDEWALK_BLE_ADV_INT_SLOW
+	int "Slow advertise interval in ms"
+	default 1000
+
+config SIDEWALK_BLE_ADV_INT_TRANSITION
+	int "Duration of fast advertisement after sid_start in seconds"
+	default 30
+
+config BT_PERIPHERAL_PREF_LATENCY
+	int "Preferred slave latency"
+	default 0
+
+config BT_PERIPHERAL_PREF_TIMEOUT
+	int "Preferred supervision timeout in 10 ms units"
+	default 400
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

[KRKNWK-21514]
Fix Sidewalk option SID_BLE_USER_CFG_ADV_AND_CONN fail (not implemented).
The aim of this PR is to avoid fault (device hangout). The option will return not implemented error code.  

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).


[KRKNWK-21514]: https://nordicsemi.atlassian.net/browse/KRKNWK-21514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ