### PR TITLE
samples,sal,doc: add nRF54LV10 DK support (BLE only)

### DIFF
--- a/doc/links.rst
+++ b/doc/links.rst
@@ -19,6 +19,7 @@
 .. _nrf5340dk: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/boards/nordic/nrf5340dk/doc/index.html
 .. _thingy53_nrf5340: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/boards/nordic/thingy53/doc/index.html
 .. _nrf54l15dk: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/boards/nordic/nrf54l15dk/doc/index.html
+.. _nrf54lv10dk: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/board_support/board_names.html
 .. _Building and programming an application: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/programming.html
 .. _Testing and debugging an application: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/test_and_optimize.html
 .. _Bootloader and DFU solutions for NCS: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/bootloaders/index.html

--- a/doc/links.rst
+++ b/doc/links.rst
@@ -2,39 +2,39 @@
 
 .. ncs links (all links need to be updated manually **right before** the targeted release)
 
-.. _nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/index.html
-.. _nrf52840: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/app_dev/device_guides/nrf52/index.html
-.. _nrf5340: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/board_support/board_names.html
-.. _nRF54L15: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/app_dev/device_guides/nrf54l/index.html
-.. _nRF54L10: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/app_dev/device_guides/nrf54l/index.html
-.. _nrf52840 DK: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/board_support/board_names.html
-.. _nrf5340 DK: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/board_support/board_names.html
-.. _Thingy53: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/board_support/board_names.html
-.. _nRF54L15 DK: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/board_support/board_names.html
-.. _Getting started with nRF52 Series: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/gsg_guides/nrf52_gs.html
-.. _Getting started with nRF53 Series: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/gsg_guides/nrf5340_gs.html
-.. _Getting started with nRF54L Series: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/gsg_guides/gsg_other.html
-.. _nRF Connect SDK Getting started: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/installation.html
-.. _nRF52840dk: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/boards/nordic/nrf52840dk/doc/index.html
-.. _nrf5340dk: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/boards/nordic/nrf5340dk/doc/index.html
-.. _thingy53_nrf5340: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/boards/nordic/thingy53/doc/index.html
-.. _nrf54l15dk: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/boards/nordic/nrf54l15dk/doc/index.html
-.. _nrf54lv10dk: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/board_support/board_names.html
-.. _Building and programming an application: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/programming.html
-.. _Testing and debugging an application: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/test_and_optimize.html
-.. _Bootloader and DFU solutions for NCS: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/config_and_build/bootloaders/index.html
-.. _Zephyr SMP Server: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/services/device_mgmt/ota.html#smp_server
-.. _Zephyr SMP Server sample: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/samples/subsys/mgmt/mcumgr/smp_svr/README.html
-.. _Zephyr State Machine Framework: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/services/smf/index.html
-.. _Zephyr Memory Storage (ZMS): https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/services/storage/zms/zms.html
+.. _nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/index.html
+.. _nrf52840: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/device_guides/nrf52/index.html
+.. _nrf5340: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
+.. _nRF54L15: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/device_guides/nrf54l/index.html
+.. _nRF54L10: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/device_guides/nrf54l/index.html
+.. _nrf52840 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
+.. _nrf5340 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
+.. _Thingy53: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
+.. _nRF54L15 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
+.. _Getting started with nRF52 Series: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/gsg_guides/nrf52_gs.html
+.. _Getting started with nRF53 Series: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/gsg_guides/nrf5340_gs.html
+.. _Getting started with nRF54L Series: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/gsg_guides/gsg_other.html
+.. _nRF Connect SDK Getting started: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/installation.html
+.. _nRF52840dk: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/boards/nordic/nrf52840dk/doc/index.html
+.. _nrf5340dk: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/boards/nordic/nrf5340dk/doc/index.html
+.. _thingy53_nrf5340: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/boards/nordic/thingy53/doc/index.html
+.. _nrf54l15dk: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/boards/nordic/nrf54l15dk/doc/index.html
+.. _nrf54lv10dk: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
+.. _Building and programming an application: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/programming.html
+.. _Testing and debugging an application: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/test_and_optimize.html
+.. _Bootloader and DFU solutions for NCS: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/bootloaders/index.html
+.. _Zephyr SMP Server: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/services/device_mgmt/ota.html#smp_server
+.. _Zephyr SMP Server sample: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/samples/subsys/mgmt/mcumgr/smp_svr/README.html
+.. _Zephyr State Machine Framework: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/services/smf/index.html
+.. _Zephyr Memory Storage (ZMS): https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/services/storage/zms/zms.html
 .. _Settings subsystem: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/settings/index.html
-.. _NCS testing applications: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/test_and_optimize.html
-.. _Installing the nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/installation/install_ncs.html
-.. _Trusted storage: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/libraries/security/trusted_storage.html
-.. _Hardware flash write protection: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/libraries/security/bootloader/fprotect.html
-.. _West: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/develop/west/index.html
-.. _Zephyr's Hello World: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/zephyr/samples/hello_world/README.html
-.. _nRF Connect SDK software maturity levels documentation: https://docs.nordicsemi.com/bundle/ncs-3.0.0/page/nrf/releases_and_maturity/software_maturity.html
+.. _NCS testing applications: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/test_and_optimize.html
+.. _Installing the nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/installation/install_ncs.html
+.. _Trusted storage: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/libraries/security/trusted_storage.html
+.. _Hardware flash write protection: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/libraries/security/bootloader/fprotect.html
+.. _West: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/develop/west/index.html
+.. _Zephyr's Hello World: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/samples/hello_world/README.html
+.. _nRF Connect SDK software maturity levels documentation: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/releases_and_maturity/software_maturity.html
 
 .. nordicsemi.com
 

--- a/doc/samples/sid_end_device.rst
+++ b/doc/samples/sid_end_device.rst
@@ -32,6 +32,8 @@ This sample supports the following development kits:
 +--------------------------------------+----------+-------------------+-------------------------------------+
 | nRF54L10 (emulating on nRF54L15 DK)  | PCA10156 | `nrf54l15dk`_     | ``nrf54l15dk/nrf54l10/cpuapp``      |
 +--------------------------------------+----------+-------------------+-------------------------------------+
+| nRF54LV10 DK                         | PCA10188 | `nrf54lv10dk`_    | ``nrf54lv10dk/nrf54lv10a/cpuapp``   |
++--------------------------------------+----------+-------------------+-------------------------------------+
 
 To run the sample in the Bluetooth LE link mode, you only need the development kit.
 However, if you want to run the sample with LoRa or FSK configuration, you also need the LoRa radio module.

--- a/doc/setting_up_sidewalk_environment/setting_up_sidewalk_prototype.rst
+++ b/doc/setting_up_sidewalk_environment/setting_up_sidewalk_prototype.rst
@@ -64,13 +64,15 @@ The tools required for provisioning are located in the repository (`sdk-nrf`_ an
 
       1. Follow the `Provision your Sidewalk endpoint and flash the binary image`_ documentation.
 
+         The nRF54L10 and nRF54LV10 share the same ``mfg_storage`` layout: 4 KB located at the end of the App-core RRAM.
+
          * If you are using the combined device JSON file obtained from the AWS IoT console, use the ``certificate_json`` parameter.
            It will specify this file as an input when running the provisioning script.
 
             .. parsed-literal::
                :class: highlight
 
-               python3 provision.py nordic aws --output_bin mfg.bin --certificate_json certificate.json --addr 0xFF000 --output_hex nordic_aws_nrf54l10.hex
+               python3 provision.py nordic aws --output_bin mfg.bin --certificate_json certificate.json --addr 0xFC000 --output_hex nordic_aws_nrf54l10.hex
 
          * If you are using separate device JSON files obtained as responses from the GetDeviceProfile and GetWirelessDevice API operations, use the ``wireless_device_json`` and ``device_profile_json`` parameters.
            This will specify both files as input when running the provisioning script.
@@ -78,11 +80,7 @@ The tools required for provisioning are located in the repository (`sdk-nrf`_ an
             .. parsed-literal::
                :class: highlight
 
-               python3 provision.py nordic aws --output_bin mfg.bin --wireless_device_json wireless_device.json --device_profile_json device_profile.json --addr 0xFF000 --output_hex nordic_aws_nrf54l10.hex
-
-            .. note::
-
-               For the nRF54L10 SoC emulating on the nRF54L15 DK, you must set the address value to ``--addr 0xFF000``.
+               python3 provision.py nordic aws --output_bin mfg.bin --wireless_device_json wireless_device.json --device_profile_json device_profile.json --addr 0xFC000 --output_hex nordic_aws_nrf54l10.hex
 
       #. Flash the generated file with the provisioning data:
 
@@ -93,6 +91,38 @@ The tools required for provisioning are located in the repository (`sdk-nrf`_ an
          * If you reflashed the :file:`nordic_aws_nrf54l10.hex` file on an already working device, you need to deregister the previously flashed device.
            To do this, perform a factory reset by long pressing **Button 0**.
            This will allow you to register a new product (new :file:`nordic_aws_nrf54l10.hex`) in the Sidewalk network.
+
+   .. group-tab:: nRF54LV10
+
+      1. Follow the `Provision your Sidewalk endpoint and flash the binary image`_ documentation.
+
+         The nRF54LV10 uses the same ``mfg_storage`` address as the nRF54L10 (4 KB at the end of the 1012 KB App-core RRAM).
+
+         * If you are using the combined device JSON file obtained from the AWS IoT console, use the ``certificate_json`` parameter.
+           It will specify this file as an input when running the provisioning script.
+
+            .. parsed-literal::
+               :class: highlight
+
+               python3 provision.py nordic aws --output_bin mfg.bin --certificate_json certificate.json --addr 0xFC000 --output_hex nordic_aws_nrf54lv10.hex
+
+         * If you are using separate device JSON files obtained as responses from the GetDeviceProfile and GetWirelessDevice API operations, use the ``wireless_device_json`` and ``device_profile_json`` parameters.
+           This will specify both files as input when running the provisioning script.
+
+            .. parsed-literal::
+               :class: highlight
+
+               python3 provision.py nordic aws --output_bin mfg.bin --wireless_device_json wireless_device.json --device_profile_json device_profile.json --addr 0xFC000 --output_hex nordic_aws_nrf54lv10.hex
+
+      #. Flash the generated file with the provisioning data:
+
+         .. code-block:: console
+
+            nrfutil device program --x-family nrf54l --options chip_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE,reset=RESET_PIN,verify=VERIFY_READ --traits jlink --firmware nordic_aws_nrf54lv10.hex
+
+         * If you reflashed the :file:`nordic_aws_nrf54lv10.hex` file on an already working device, you need to deregister the previously flashed device.
+           To do this, perform a factory reset by long pressing **Button 0**.
+           This will allow you to register a new product (new :file:`nordic_aws_nrf54lv10.hex`) in the Sidewalk network.
 
    .. group-tab:: nRF54L15
 
@@ -117,10 +147,6 @@ The tools required for provisioning are located in the repository (`sdk-nrf`_ an
                :class: highlight
 
                python3 provision.py nordic aws --output_bin mfg.bin --wireless_device_json wireless_device.json --device_profile_json device_profile.json --addr 0x17c000 --output_hex nordic_aws_nrf54l15.hex
-
-            .. note::
-
-               For the nRF54L10 SoC emulating on the nRF54L15 DK, you must set the address value to ``--addr 0xFF000``.
 
       #. Flash the generated file with the provisioning data:
 

--- a/doc/setting_up_sidewalk_environment/setting_up_sidewalk_prototype.rst
+++ b/doc/setting_up_sidewalk_environment/setting_up_sidewalk_prototype.rst
@@ -64,7 +64,7 @@ The tools required for provisioning are located in the repository (`sdk-nrf`_ an
 
       1. Follow the `Provision your Sidewalk endpoint and flash the binary image`_ documentation.
 
-         The nRF54L10 and nRF54LV10 share the same ``mfg_storage`` layout: 4 KB located at the end of the App-core RRAM.
+         The nRF54L10 and nRF54LV10 DKs share the same ``mfg_storage`` layout: 4 KB located at the end of the application core RRAM.
 
          * If you are using the combined device JSON file obtained from the AWS IoT console, use the ``certificate_json`` parameter.
            It will specify this file as an input when running the provisioning script.
@@ -92,11 +92,11 @@ The tools required for provisioning are located in the repository (`sdk-nrf`_ an
            To do this, perform a factory reset by long pressing **Button 0**.
            This will allow you to register a new product (new :file:`nordic_aws_nrf54l10.hex`) in the Sidewalk network.
 
-   .. group-tab:: nRF54LV10
+   .. group-tab:: nRF54LV10 DK
 
       1. Follow the `Provision your Sidewalk endpoint and flash the binary image`_ documentation.
 
-         The nRF54LV10 uses the same ``mfg_storage`` address as the nRF54L10 (4 KB at the end of the 1012 KB App-core RRAM).
+         The nRF54LV10 DK uses the same ``mfg_storage`` address as the nRF54L10 DK (4 KB at the end of the 1012 KB application core RRAM).
 
          * If you are using the combined device JSON file obtained from the AWS IoT console, use the ``certificate_json`` parameter.
            It will specify this file as an input when running the provisioning script.

--- a/samples/sid_end_device/Kconfig.sysbuild
+++ b/samples/sid_end_device/Kconfig.sysbuild
@@ -32,7 +32,7 @@ config MERGED_HEX_FILES
 	default y
 
 config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y if !SOC_NRF54L15
+	default y if !SOC_NRF54L15 && !SOC_NRF54LV10A
 
 if SOC_SERIES_NRF53X
 

--- a/samples/sid_end_device/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/sid_end_device/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -14,7 +14,7 @@
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1024)>;
+	reg = <0x0 DT_SIZE_K(1012)>;
 };
 
 &cpuapp_sram {
@@ -67,17 +67,17 @@
 
 		slot0_partition: partition@d000 {
 			label = "image-0";
-			reg = <0xd000 DT_SIZE_K(960)>;
+			reg = <0xd000 DT_SIZE_K(944)>;
 		};
 
-		storage_partition: partition@fd000 {
+		storage_partition: partition@f9000 {
 			label = "storage";
-			reg = <0xfd000 DT_SIZE_K(8)>;
+			reg = <0xf9000 DT_SIZE_K(12)>;
 		};
 
-		mfg_storage: partition@ff000 {
+		mfg_storage: partition@fc000 {
 			label = "mfg_storage";
-			reg = <0xff000 DT_SIZE_K(4)>;
+			reg = <0xfc000 DT_SIZE_K(4)>;
 		};
 	};
 };
@@ -90,7 +90,7 @@
 
 		slot1_partition: partition@0 {
 			label = "image-1";
-			reg = <0x0 DT_SIZE_K(960)>;
+			reg = <0x0 DT_SIZE_K(944)>;
 		};
 	};
 };

--- a/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_POWEROFF=y
+
+# ZMS cache optimization
+CONFIG_ZMS_LOOKUP_CACHE=y
+CONFIG_ZMS_LOOKUP_CACHE_SIZE=512
+CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS=y
+
+# LTO to fit within RRAM constraints
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		state-notifier-connected = &led0;
+		state-notifier-time-sync = &led1;
+		state-notifier-registered = &led2;
+		state-notifier-working = &led3;
+	};
+};
+
+&adc {
+	status = "disabled";
+};
+&uart20 {
+	status = "disabled";
+};
+&uart21 {
+	status = "disabled";
+};
+&i2c20 {
+	status = "disabled";
+};
+&spi20 {
+	status = "disabled";
+};
+&i2c21 {
+	status = "disabled";
+};
+&spi21 {
+	status = "disabled";
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(48)>;
+		};
+
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0xc000 DT_SIZE_K(444)>;
+		};
+
+		slot1_partition: partition@7b000 {
+			label = "image-1";
+			reg = <0x7b000 DT_SIZE_K(444)>;
+		};
+
+		storage_partition: partition@ea000 {
+			label = "storage";
+			reg = <0xea000 DT_SIZE_K(8)>;
+		};
+
+		mfg_storage: partition@ec000 {
+			label = "mfg_storage";
+			reg = <0xec000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -41,7 +41,7 @@
 /delete-node/ &storage_partition;
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1024)>;
+	reg = <0x0 DT_SIZE_K(1012)>;
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -54,22 +54,22 @@
 
 		slot0_partition: partition@d000 {
 			label = "image-0";
-			reg = <0xd000 DT_SIZE_K(480)>;
+			reg = <0xd000 DT_SIZE_K(472)>;
 		};
 
-		slot1_partition: partition@85000 {
+		slot1_partition: partition@83000 {
 			label = "image-1";
-			reg = <0x85000 DT_SIZE_K(480)>;
+			reg = <0x83000 DT_SIZE_K(472)>;
 		};
 
-		storage_partition: partition@fd000 {
+		storage_partition: partition@f9000 {
 			label = "storage";
-			reg = <0xfd000 DT_SIZE_K(8)>;
+			reg = <0xf9000 DT_SIZE_K(12)>;
 		};
 
-		mfg_storage: partition@ff000 {
+		mfg_storage: partition@fc000 {
 			label = "mfg_storage";
-			reg = <0xff000 DT_SIZE_K(4)>;
+			reg = <0xfc000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/sid_end_device/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -41,6 +41,7 @@
 /delete-node/ &storage_partition;
 
 &cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1024)>;
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -48,27 +49,27 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(48)>;
+			reg = <0x0 DT_SIZE_K(52)>;
 		};
 
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@d000 {
 			label = "image-0";
-			reg = <0xc000 DT_SIZE_K(444)>;
+			reg = <0xd000 DT_SIZE_K(480)>;
 		};
 
-		slot1_partition: partition@7b000 {
+		slot1_partition: partition@85000 {
 			label = "image-1";
-			reg = <0x7b000 DT_SIZE_K(444)>;
+			reg = <0x85000 DT_SIZE_K(480)>;
 		};
 
-		storage_partition: partition@ea000 {
+		storage_partition: partition@fd000 {
 			label = "storage";
-			reg = <0xea000 DT_SIZE_K(8)>;
+			reg = <0xfd000 DT_SIZE_K(8)>;
 		};
 
-		mfg_storage: partition@ec000 {
+		mfg_storage: partition@ff000 {
 			label = "mfg_storage";
-			reg = <0xec000 DT_SIZE_K(4)>;
+			reg = <0xff000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -10,6 +10,7 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
+    - nrf54lv10dk/nrf54lv10a/cpuapp
 tests:
   sample.sidewalk.hello.sx1262:
     integration_platforms:
@@ -102,12 +103,14 @@ tests:
     build_only: false
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.ble_only"
     harness: console
@@ -127,6 +130,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.ble_only.release"
@@ -232,12 +236,14 @@ tests:
     build_only: false
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-dut.conf"
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="dut.ble_only"

--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -1,6 +1,7 @@
 sample:
   name: Sidewalk end device sample
   description: Sample implementing Amazon Sidewalk End Device
+
 common:
   sysbuild: true
   build_only: true
@@ -10,14 +11,13 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
+  integration_platforms:
+    - nrf54l15dk/nrf54l15/cpuapp
+  tags:
+    - Sidewalk
+
 tests:
   sample.sidewalk.hello.sx1262:
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-hello.conf"
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -26,21 +26,13 @@ tests:
       - CONFIG_SIDEWALK_FILE_TRANSFER=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello"
     tags:
-      - Sidewalk
       - hello
       - sx1262
 
   sample.sidewalk.hello.lr1110:
     build_only: false
-    platform_allow:
-      - nrf52840dk/nrf52840
     platform_exclude:
       - nrf5340dk/nrf5340/cpuapp
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-hello.conf"
       - SHIELD="simple_arduino_adapter;semtech_lr1110mb1xxs"
@@ -54,17 +46,10 @@ tests:
       regex:
         - ".*Booting Sidewalk.*"
     tags:
-      - Sidewalk
       - hello
       - lr1110
 
   sample.sidewalk.hello.release.sx1262:
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - FILE_SUFFIX=release
       - OVERLAY_CONFIG="overlay-hello.conf"
@@ -73,18 +58,12 @@ tests:
       - CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.release"
     tags:
-      - Sidewalk
       - hello
       - sx1262
 
   sample.sidewalk.hello.release.lr1110:
     platform_exclude:
       - nrf5340dk/nrf5340/cpuapp
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - FILE_SUFFIX=release
       - OVERLAY_CONFIG="overlay-hello.conf"
@@ -94,21 +73,12 @@ tests:
       - CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.release"
     tags:
-      - Sidewalk
       - hello
       - lr1110
 
   sample.sidewalk.hello.ble_only:
     build_only: false
     platform_allow:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.ble_only"
@@ -118,33 +88,20 @@ tests:
       regex:
         - ".*Booting Sidewalk.*"
     tags:
-      - Sidewalk
       - hello
       - BLE
 
   sample.sidewalk.hello.ble_only.release:
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
+    platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.ble_only.release"
     tags:
-      - Sidewalk
       - hello
       - BLE
 
   sample.sidewalk.demo.sx1262:
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-demo.conf"
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -152,18 +109,12 @@ tests:
       - CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="demo"
     tags:
-      - Sidewalk
       - demo
       - sx1262
 
   sample.sidewalk.demo.lr1110:
     platform_exclude:
       - nrf5340dk/nrf5340/cpuapp
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-demo.conf"
       - SHIELD="simple_arduino_adapter;semtech_lr1110mb1xxs"
@@ -171,7 +122,6 @@ tests:
       - CONFIG_SID_END_DEVICE_PERSISTENT_LINK_MASK=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="demo"
     tags:
-      - Sidewalk
       - demo
       - lr1110
 
@@ -184,38 +134,26 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     tags:
-      - Sidewalk
       - demo
       - BLE
 
   sample.sidewalk.dut.sx1262:
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-dut.conf"
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="dut"
     tags:
-      - Sidewalk
       - cli
       - sx1262
 
   sample.sidewalk.dut.lr1110:
     build_only: false
-    platform_allow:
-      - nrf52840dk/nrf52840
     platform_exclude:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-dut.conf"
       - SHIELD="simple_arduino_adapter;semtech_lr1110mb1xxs"
@@ -227,21 +165,12 @@ tests:
       regex:
         - "uart:~\\$"
     tags:
-      - Sidewalk
       - cli
       - lr1110
 
   sample.sidewalk.dut.ble_only:
     build_only: false
     platform_allow:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-dut.conf"
     extra_configs:
@@ -252,17 +181,12 @@ tests:
       regex:
         - "uart:~\\$"
     tags:
-      - Sidewalk
       - cli
       - BLE
 
   sample.sidewalk.dut.no_secure:
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-dut.conf"
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -270,7 +194,6 @@ tests:
       - CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE=n
       - CONFIG_SIDEWALK_APPLICATION_NAME="dut.no_secure"
     tags:
-      - Sidewalk
       - cli
       - no_secure
 
@@ -286,7 +209,6 @@ tests:
       - CONFIG_SIDEWALK_LINK_MASK_BLE=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.release.ble"
     tags:
-      - Sidewalk
       - helloPower
 
   sample.sidewalk.helloPower.fsk.release.sx1262:
@@ -303,7 +225,6 @@ tests:
       - CONFIG_SIDEWALK_LINK_MASK_FSK=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.release.fsk"
     tags:
-      - Sidewalk
       - helloPower
       - sx1262
 
@@ -321,7 +242,6 @@ tests:
       - CONFIG_SIDEWALK_LINK_MASK_LORA=y
       - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.release.lora"
     tags:
-      - Sidewalk
       - helloPower
       - sx1262
 
@@ -331,11 +251,12 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
+    platform_allow:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_STATE_NOTIFIER=n
       - CONFIG_SIDEWALK_APPLICATION_NAME="helloPower.ble_only.release"
     tags:
-      - Sidewalk
       - helloPower
       - BLE

--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -10,7 +10,6 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
-    - nrf54lv10dk/nrf54lv10a/cpuapp
 tests:
   sample.sidewalk.hello.sx1262:
     integration_platforms:

--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -172,6 +172,7 @@ tests:
     build_only: false
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-dut.conf"
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="dut.ble_only"

--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
+
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y
+
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
+
+# Ensure that the spi driver is disabled by default
+CONFIG_SPI=n
+CONFIG_SPI_NOR=n

--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -9,9 +9,6 @@
 # for protection more than one region.
 CONFIG_FPROTECT=n
 
-# TODO: Workaround, disable memory guard to avoid false faults in application after boot
-CONFIG_HW_STACK_PROTECTION=n
-
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before
@@ -20,8 +17,6 @@ CONFIG_HW_STACK_PROTECTION=n
 CONFIG_TICKLESS_KERNEL=y
 
 CONFIG_BOOT_WATCHDOG_FEED=n
-
-CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # Ensure that the spi driver is disabled by default
 CONFIG_SPI=n

--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/subsys/sal/sid_pal/src/sid_mfg_storage.c
+++ b/subsys/sal/sid_pal/src/sid_mfg_storage.c
@@ -48,7 +48,7 @@ static int sid_mfg_storage_secure_read(uint16_t *p_value, uint8_t *buffer, uint1
 #elif defined(NRF_NETWORK)
 #define DEV_ID_REG (uint32_t)(NRF_FICR_NS->INFO.DEVICEID[0])
 #endif /* NRF5340_XXAA */
-#elif defined(NRF54L10_XXAA) || defined(NRF54L15_XXAA)
+#elif defined(NRF54L10_XXAA) || defined(NRF54L15_XXAA) || defined(NRF54LV10A_XXAA)
 #define DEV_ID_REG (uint32_t)(NRF_FICR->INFO.DEVICEID[0])
 #else
 #error "Unknow Device ID register."

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: sidewalk
 build:
   cmake: .
   kconfig: Kconfig


### PR DESCRIPTION
## Summary

- Add `nrf54lv10dk/nrf54lv10a/cpuapp` board support to `sid_end_device` sample (hello and dut BLE-only variants)
- `sample.yaml`: add platform to `hello.ble_only`, `hello.ble_only.release`, `dut.ble_only` integration test lists
- `zephyr/module.yml`: add explicit `name: sidewalk` for correct module override in git-worktree builds
- Docs: add nRF54LV10 DK row (PCA10188) and board link

