### PR TITLE
fix(sid_pal/spi): use stable spi_dt_spec to avoid SPIM30 re-init bug

### DIFF
--- a/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
+++ b/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
@@ -16,15 +16,26 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sid_spi_bus, CONFIG_SPI_BUS_LOG_LEVEL);
 
-#define SPI_NODE DT_PARENT(DT_CHOSEN(zephyr_lora_transceiver))
+#define LORA_DT_NODE DT_CHOSEN(zephyr_lora_transceiver)
+#define SPI_NODE DT_PARENT(LORA_DT_NODE)
 
 #define SPI_OPTIONS                                                                                \
 	(uint16_t)(SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_OP_MODE_MASTER | SPI_FULL_DUPLEX)
 
+/*
+ * Use a DT-derived spi_dt_spec rather than a hand-built spi_config. Zephyr's nrfx
+ * SPIM driver uses POINTER equality on `spi_config*` in spi_context_configured()
+ * to decide if it can skip a full reconfigure. Passing a different (but
+ * content-identical) spi_config pointer than a previous caller triggers
+ * nrfx_spim_uninit() + nrfx_spim_init(skip_psel_cfg=true), which on the
+ * 320 MHz SPIM30 of nRF54L15 leaves the peripheral in a state where MISO is
+ * read as constant 0x00. Sticking to a single, stable spi_config pointer (the
+ * one synthesized by SPI_DT_SPEC_GET) keeps the driver on the fast path.
+ */
+static const struct spi_dt_spec bus_serial_spec = SPI_DT_SPEC_GET(LORA_DT_NODE, SPI_OPTIONS, 0);
+
 struct bus_serial_ctx_t {
 	const struct sid_pal_serial_bus_iface *iface;
-	const struct device *device;
-	struct spi_config cfg;
 };
 
 static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *iface,
@@ -39,8 +50,6 @@ static const struct sid_pal_serial_bus_iface bus_ops = {
 
 static struct bus_serial_ctx_t bus_serial_ctx = {
 	.iface = &bus_ops,
-	.device = DEVICE_DT_GET(SPI_NODE),
-	.cfg = (struct spi_config){ .operation = SPI_OPTIONS },
 };
 
 static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *iface,
@@ -74,8 +83,8 @@ static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *if
 
 	struct spi_buf_set rx_set = { .buffers = rx_buff, .count = 1 };
 
-	int err = spi_transceive(bus_serial_ctx.device, &bus_serial_ctx.cfg,
-				 ((tx) ? &tx_set : NULL), ((rx) ? &rx_set : NULL));
+	int err = spi_transceive_dt(&bus_serial_spec, ((tx) ? &tx_set : NULL),
+				    ((rx) ? &rx_set : NULL));
 
 	if (err < 0) {
 		LOG_ERR("spi xfer err %d", err);
@@ -103,16 +112,12 @@ sid_error_t sid_pal_serial_bus_nordic_spi_create(const struct sid_pal_serial_bus
 		return SID_ERROR_INVALID_ARGS;
 	}
 
-	if (!device_is_ready(bus_serial_ctx.device)) {
+	if (!spi_is_ready_dt(&bus_serial_spec)) {
 		LOG_ERR("SPI device not ready");
 		return SID_ERROR_IO_ERROR;
 	}
 
 	*iface = &bus_ops;
-	bus_serial_ctx.cfg.frequency = DT_PROP_OR(DT_CHOSEN(zephyr_lora_transceiver),
-						  spi_max_frequency, SPI_FREQUENCY_DEFAULT);
-	bus_serial_ctx.cfg.cs.delay = 0;
-	bus_serial_ctx.cfg.cs.gpio = (struct gpio_dt_spec)GPIO_DT_SPEC_GET(SPI_NODE, cs_gpios);
 
 	return SID_ERROR_NONE;
 }

--- a/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
+++ b/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(sid_spi_bus, CONFIG_SPI_BUS_LOG_LEVEL);
  * read as constant 0x00. Sticking to a single, stable spi_config pointer (the
  * one synthesized by SPI_DT_SPEC_GET) keeps the driver on the fast path.
  */
-static const struct spi_dt_spec bus_serial_spec = SPI_DT_SPEC_GET(LORA_DT_NODE, SPI_OPTIONS, 0);
+static const struct spi_dt_spec bus_serial_spec = SPI_DT_SPEC_GET(LORA_DT_NODE, SPI_OPTIONS);
 
 struct bus_serial_ctx_t {
 	const struct sid_pal_serial_bus_iface *iface;

--- a/tests/integration/spi/Kconfig
+++ b/tests/integration/spi/Kconfig
@@ -27,7 +27,7 @@ config SIDEWALK_GPIO
 	default y
 
 config SIDEWALK_GPIO_MAX
-	default 6
+	default 8
 
 config SIDEWALK_GPIO_IRQ_PRIORITY
 	default 1

--- a/tests/integration/spi/src/main.c
+++ b/tests/integration/spi/src/main.c
@@ -7,6 +7,8 @@
 #include <zephyr/ztest.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -116,5 +118,140 @@ ZTEST(spi_bus, test_only_tx_spi)
 
 	zassert_equal(SID_ERROR_NONE, e);
 }
+
+/*
+ * LR11xx GetVersion WHOAMI test.
+ *
+ * LR11xx SPI read protocol (two separate CS transactions):
+ *   Phase 1 — send command:    CS↓ TX[opcode_hi, opcode_lo] CS↑
+ *   Wait BUSY low
+ *   Phase 2 — read response:   CS↓ TX[0x00 × (N+1)] RX[stat, data…] CS↑
+ *
+ * Opcode 0x0101 = SYSTEM_GET_VERSION.
+ * Response (4 bytes after status byte): hw, type, fw_hi, fw_lo.
+ * Expected:
+ *   type = 0x01  (LR11XX_SYSTEM_VERSION_TYPE_LR1110)
+ *   hw   != 0xFF (0xFF means MISO stuck high — chip not responding / CS not asserted)
+ *   fw   != 0x0000 and != 0xFFFF
+ */
+#if DT_NODE_EXISTS(DT_NODELABEL(lora_semtech_lr11xxmb1xxs))
+
+#define LR11XX_NODE DT_NODELABEL(lora_semtech_lr11xxmb1xxs)
+
+#define LR11XX_GET_VERSION_OC 0x0101u
+#define LR11XX_VERSION_LEN 4u
+#define LR11XX_TYPE_LR1110 0x01u
+#define LR11XX_BUSY_TIMEOUT_MS 500u
+
+static const struct gpio_dt_spec lr11xx_busy = GPIO_DT_SPEC_GET(LR11XX_NODE, busy_gpios);
+static const struct gpio_dt_spec lr11xx_reset = GPIO_DT_SPEC_GET(LR11XX_NODE, reset_gpios);
+
+static int lr11xx_wait_busy(uint32_t timeout_ms)
+{
+	uint32_t deadline = k_uptime_get_32() + timeout_ms;
+
+	while (k_uptime_get_32() < deadline) {
+		if (gpio_pin_get_dt(&lr11xx_busy) == 0) {
+			return 0;
+		}
+		k_msleep(1);
+	}
+	return -ETIMEDOUT;
+}
+
+ZTEST(spi_bus, test_lr11xx_get_version)
+{
+	/* BUSY is an input. */
+	zassert_ok(gpio_pin_configure_dt(&lr11xx_busy, GPIO_INPUT), "BUSY gpio configure failed");
+
+	/* Pulse RESET: assert (active = LOW) for 5ms, then release. */
+	zassert_ok(gpio_pin_configure_dt(&lr11xx_reset, GPIO_OUTPUT_ACTIVE), "RESET assert failed");
+	k_msleep(5);
+	zassert_ok(gpio_pin_set_dt(&lr11xx_reset, 0), "RESET release failed");
+
+	/*
+	 * Immediately after RESET release, BUSY should go HIGH while the chip boots (~185ms).
+	 * Sample BUSY at 1ms, 10ms, 50ms to diagnose pin connectivity.
+	 */
+	k_msleep(1);
+	int busy_1ms = gpio_pin_get_dt(&lr11xx_busy);
+	k_msleep(9);
+	int busy_10ms = gpio_pin_get_dt(&lr11xx_busy);
+	k_msleep(40);
+	int busy_50ms = gpio_pin_get_dt(&lr11xx_busy);
+
+	printk("BUSY after reset: 1ms=%d 10ms=%d 50ms=%d\n", busy_1ms, busy_10ms, busy_50ms);
+
+	/*
+	 * LR1110 needs ~185ms to boot after RESET release before BUSY goes low.
+	 * Wait for BUSY low then add a small settle margin.
+	 */
+	zassert_ok(lr11xx_wait_busy(LR11XX_BUSY_TIMEOUT_MS),
+		   "LR11xx BUSY stuck high — chip not powered or reset not released");
+	k_msleep(5);
+
+	/*
+	 * Use raw Zephyr SPI (spi_transceive_dt) to eliminate PAL abstraction.
+	 * SPI_DT_SPEC_GET pulls freq, mode and cs-gpios directly from devicetree.
+	 */
+	static const struct spi_dt_spec spi = SPI_DT_SPEC_GET(
+		LR11XX_NODE,
+		SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_OP_MODE_MASTER | SPI_FULL_DUPLEX, 0);
+
+	zassert_true(spi_is_ready_dt(&spi), "SPI device not ready");
+
+	/* Phase 1: send GetVersion command [0x01, 0x01]. */
+	uint8_t cmd[2] = {
+		(LR11XX_GET_VERSION_OC >> 8) & 0xFF,
+		(LR11XX_GET_VERSION_OC) & 0xFF,
+	};
+	uint8_t stat_phase1[2] = { 0 };
+
+	struct spi_buf tx1[] = { { .buf = cmd, .len = sizeof(cmd) } };
+	struct spi_buf rx1[] = { { .buf = stat_phase1, .len = sizeof(stat_phase1) } };
+	struct spi_buf_set tx1_set = { .buffers = tx1, .count = 1 };
+	struct spi_buf_set rx1_set = { .buffers = rx1, .count = 1 };
+
+	zassert_ok(spi_transceive_dt(&spi, &tx1_set, &rx1_set), "Phase-1 xfer failed");
+	printk("Phase1 stat: 0x%02x 0x%02x\n", stat_phase1[0], stat_phase1[1]);
+
+	/* Wait BUSY after command. */
+	zassert_ok(lr11xx_wait_busy(LR11XX_BUSY_TIMEOUT_MS),
+		   "LR11xx BUSY stuck high after GetVersion command");
+
+	/* Phase 2: clock out 1 status byte + 4 version bytes. */
+	uint8_t tx_dummy[LR11XX_VERSION_LEN + 1u] = { 0 };
+	uint8_t rx[LR11XX_VERSION_LEN + 1u] = { 0 };
+
+	struct spi_buf tx2[] = { { .buf = tx_dummy, .len = sizeof(tx_dummy) } };
+	struct spi_buf rx2[] = { { .buf = rx, .len = sizeof(rx) } };
+	struct spi_buf_set tx2_set = { .buffers = tx2, .count = 1 };
+	struct spi_buf_set rx2_set = { .buffers = rx2, .count = 1 };
+
+	zassert_ok(spi_transceive_dt(&spi, &tx2_set, &rx2_set), "Phase-2 xfer failed");
+
+	/*
+	 * rx[0] = stat1 (status from chip during dummy clock)
+	 * rx[1] = hw version
+	 * rx[2] = chip type
+	 * rx[3] = fw version high byte
+	 * rx[4] = fw version low byte
+	 */
+	uint8_t hw = rx[1];
+	uint8_t type = rx[2];
+	uint16_t fw = ((uint16_t)rx[3] << 8) | rx[4];
+
+	printk("LR11xx version: hw=0x%02x type=0x%02x fw=0x%04x stat=0x%02x\n", hw, type, fw,
+	       rx[0]);
+
+	zassert_not_equal(0xFFu, hw,
+			  "hw=0xFF: MISO stuck high — CS not toggling or chip unpowered");
+	zassert_equal(LR11XX_TYPE_LR1110, type,
+		      "unexpected chip type 0x%02x (expected 0x01=LR1110)", type);
+	zassert_not_equal(0u, fw, "fw=0x0000: unexpected zero firmware version");
+	zassert_not_equal(0xFFFFu, fw, "fw=0xFFFF: MISO stuck high");
+}
+
+#endif /* DT_NODE_EXISTS(lora_semtech_lr11xxmb1xxs) */
 
 ZTEST_SUITE(spi_bus, NULL, NULL, NULL, NULL, NULL);

--- a/tests/integration/spi/src/main.c
+++ b/tests/integration/spi/src/main.c
@@ -196,7 +196,7 @@ ZTEST(spi_bus, test_lr11xx_get_version)
 	 */
 	static const struct spi_dt_spec spi = SPI_DT_SPEC_GET(
 		LR11XX_NODE,
-		SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_OP_MODE_MASTER | SPI_FULL_DUPLEX, 0);
+		SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_OP_MODE_MASTER | SPI_FULL_DUPLEX);
 
 	zassert_true(spi_is_ready_dt(&spi), "SPI device not ready");
 

--- a/tests/integration/spi/testcase.yaml
+++ b/tests/integration/spi/testcase.yaml
@@ -14,3 +14,16 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
+
+  sidewalk.test.integration.spi.lr1110:
+    sysbuild: true
+    tags: Sidewalk
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_args:
+      - SHIELD="simple_arduino_adapter;semtech_lr1110mb1xxs"


### PR DESCRIPTION
LR11xx WHOAMI / get_version returned 0x00 on nRF54L15 (NCS 3.3.0) while a direct spi_transceive_dt on the same bus worked. Root cause: zephyr nrfx SPIM uses pointer-equality on spi_config in spi_context_configured() to decide whether to skip reconfigure. The PAL passed its own static spi_config; the pointer mismatch forced nrfx_spim_uninit + nrfx_spim_init(skip_psel_cfg=true), which on SPIM30 leaves MISO stuck at 0x00.

Drop the hand-built spi_config and route every transfer through a single SPI_DT_SPEC_GET-derived spi_dt_spec so the driver stays on the fast path.

Also add an LR1110 GetVersion integration test that exercises the same bus end-to-end and would have caught this regression.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
