### PR TITLE
Fix spi pal after migration to NCS v3.3.0

### DIFF
--- a/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
+++ b/subsys/sal/sid_pal/src/sid_pal_serial_bus_spi.c
@@ -16,34 +16,24 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sid_spi_bus, CONFIG_SPI_BUS_LOG_LEVEL);
 
-#define SPI_NODE DT_PARENT(DT_CHOSEN(zephyr_lora_transceiver))
+#define LORA_DT_NODE DT_CHOSEN(zephyr_lora_transceiver)
 
 #define SPI_OPTIONS                                                                                \
 	(uint16_t)(SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_OP_MODE_MASTER | SPI_FULL_DUPLEX)
 
-struct bus_serial_ctx_t {
-	const struct sid_pal_serial_bus_iface *iface;
-	const struct device *device;
-	struct spi_config cfg;
-};
+static const struct spi_dt_spec bus_serial_spec = SPI_DT_SPEC_GET(LORA_DT_NODE, SPI_OPTIONS);
 
-static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *iface,
+static sid_error_t zephyr_spi_bus_xfer(const struct sid_pal_serial_bus_iface *iface,
 				       const struct sid_pal_serial_bus_client *client, uint8_t *tx,
 				       uint8_t *rx, size_t xfer_size);
-static sid_error_t bus_serial_spi_destroy(const struct sid_pal_serial_bus_iface *iface);
+static sid_error_t zephyr_spi_bus_destroy(const struct sid_pal_serial_bus_iface *iface);
 
-static const struct sid_pal_serial_bus_iface bus_ops = {
-	.xfer = bus_serial_spi_xfer,
-	.destroy = bus_serial_spi_destroy,
+static const struct sid_pal_serial_bus_iface zephyr_spi_bus_iface = {
+	.xfer = zephyr_spi_bus_xfer,
+	.destroy = zephyr_spi_bus_destroy,
 };
 
-static struct bus_serial_ctx_t bus_serial_ctx = {
-	.iface = &bus_ops,
-	.device = DEVICE_DT_GET(SPI_NODE),
-	.cfg = (struct spi_config){ .operation = SPI_OPTIONS },
-};
-
-static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *iface,
+static sid_error_t zephyr_spi_bus_xfer(const struct sid_pal_serial_bus_iface *iface,
 				       const struct sid_pal_serial_bus_client *client, uint8_t *tx,
 				       uint8_t *rx, size_t xfer_size)
 {
@@ -52,7 +42,7 @@ static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *if
 
 	sid_error_t ret = SID_ERROR_NONE;
 
-	if (iface != bus_serial_ctx.iface || (!tx && !rx) || !xfer_size || !client) {
+	if (iface != &zephyr_spi_bus_iface || (!tx && !rx) || !xfer_size || !client) {
 		return SID_ERROR_INVALID_ARGS;
 	}
 
@@ -74,8 +64,8 @@ static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *if
 
 	struct spi_buf_set rx_set = { .buffers = rx_buff, .count = 1 };
 
-	int err = spi_transceive(bus_serial_ctx.device, &bus_serial_ctx.cfg,
-				 ((tx) ? &tx_set : NULL), ((rx) ? &rx_set : NULL));
+	int err = spi_transceive_dt(&bus_serial_spec, ((tx) ? &tx_set : NULL),
+				    ((rx) ? &rx_set : NULL));
 
 	if (err < 0) {
 		LOG_ERR("spi xfer err %d", err);
@@ -85,7 +75,7 @@ static sid_error_t bus_serial_spi_xfer(const struct sid_pal_serial_bus_iface *if
 	return ret;
 }
 
-static sid_error_t bus_serial_spi_destroy(const struct sid_pal_serial_bus_iface *iface)
+static sid_error_t zephyr_spi_bus_destroy(const struct sid_pal_serial_bus_iface *iface)
 {
 	LOG_DBG("%s(%p)", __func__, iface);
 	if (!iface) {
@@ -103,16 +93,12 @@ sid_error_t sid_pal_serial_bus_nordic_spi_create(const struct sid_pal_serial_bus
 		return SID_ERROR_INVALID_ARGS;
 	}
 
-	if (!device_is_ready(bus_serial_ctx.device)) {
+	if (!spi_is_ready_dt(&bus_serial_spec)) {
 		LOG_ERR("SPI device not ready");
 		return SID_ERROR_IO_ERROR;
 	}
 
-	*iface = &bus_ops;
-	bus_serial_ctx.cfg.frequency = DT_PROP_OR(DT_CHOSEN(zephyr_lora_transceiver),
-						  spi_max_frequency, SPI_FREQUENCY_DEFAULT);
-	bus_serial_ctx.cfg.cs.delay = 0;
-	bus_serial_ctx.cfg.cs.gpio = (struct gpio_dt_spec)GPIO_DT_SPEC_GET(SPI_NODE, cs_gpios);
+	*iface = &zephyr_spi_bus_iface;
 
 	return SID_ERROR_NONE;
 }

--- a/tests/integration/spi/Kconfig
+++ b/tests/integration/spi/Kconfig
@@ -27,7 +27,7 @@ config SIDEWALK_GPIO
 	default y
 
 config SIDEWALK_GPIO_MAX
-	default 6
+	default 8
 
 config SIDEWALK_GPIO_IRQ_PRIORITY
 	default 1

--- a/tests/integration/spi/src/main.c
+++ b/tests/integration/spi/src/main.c
@@ -7,6 +7,8 @@
 #include <zephyr/ztest.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -17,7 +19,10 @@
 #include <sid_pal_serial_bus_ifc.h>
 #include <sid_pal_serial_bus_spi_config.h>
 
-#define NULL_STRUCT_INITIALIZER { 0 }
+#define NULL_STRUCT_INITIALIZER                                                                    \
+	{                                                                                          \
+		0                                                                                  \
+	}
 #define INVALID_DT_GPIO NULL_STRUCT_INITIALIZER
 
 ZTEST(spi_bus, test_init_spi)
@@ -116,5 +121,67 @@ ZTEST(spi_bus, test_only_tx_spi)
 
 	zassert_equal(SID_ERROR_NONE, e);
 }
+
+/* LR11xx GetVersion smoke test using sid_pal serial bus interface. */
+#if DT_NODE_EXISTS(DT_NODELABEL(lora_semtech_lr11xxmb1xxs))
+
+#define LR11XX_NODE DT_NODELABEL(lora_semtech_lr11xxmb1xxs)
+
+#define LR11XX_GET_VERSION_OC 0x0101u
+#define LR11XX_VERSION_LEN 4u
+#define LR11XX_TYPE_LR1110 0x01u
+#define LR11XX_BUSY_TIMEOUT_MS 500u
+
+static const struct gpio_dt_spec lr11xx_busy = GPIO_DT_SPEC_GET(LR11XX_NODE, busy_gpios);
+
+static int lr11xx_wait_busy(uint32_t timeout_ms)
+{
+	uint32_t deadline = k_uptime_get_32() + timeout_ms;
+
+	while (k_uptime_get_32() < deadline) {
+		if (gpio_pin_get_dt(&lr11xx_busy) == 0) {
+			return 0;
+		}
+		k_msleep(1);
+	}
+
+	return -ETIMEDOUT;
+}
+
+ZTEST(spi_bus, test_lr11xx_get_version)
+{
+	const struct sid_pal_serial_bus_iface *interface = NULL;
+	struct sid_pal_serial_bus_client client;
+	uint8_t cmd[] = {
+		(uint8_t)((LR11XX_GET_VERSION_OC >> 8) & 0xFF),
+		(uint8_t)(LR11XX_GET_VERSION_OC & 0xFF),
+	};
+	uint8_t tx_dummy[LR11XX_VERSION_LEN + 1u] = { 0 };
+	uint8_t rx[LR11XX_VERSION_LEN + 1u] = { 0 };
+
+	client.client_selector = sid_gpio_utils_register_gpio(
+		(struct gpio_dt_spec)SPI_CS_GPIOS_DT_SPEC_GET(LR11XX_NODE));
+	sid_pal_gpio_set_direction(client.client_selector, SID_PAL_GPIO_DIRECTION_OUTPUT);
+	zassert_ok(gpio_pin_configure_dt(&lr11xx_busy, GPIO_INPUT), "BUSY gpio configure failed");
+
+	zassert_equal(SID_ERROR_NONE, sid_pal_serial_bus_nordic_spi_create(&interface, NULL));
+	zassert_not_null(interface);
+	zassert_not_null(interface->xfer);
+
+	/* LR11xx read command is two SPI transactions. */
+	zassert_ok(lr11xx_wait_busy(LR11XX_BUSY_TIMEOUT_MS), "BUSY stuck high before command");
+	zassert_equal(SID_ERROR_NONE, interface->xfer(interface, &client, cmd, NULL, sizeof(cmd)));
+	zassert_ok(lr11xx_wait_busy(LR11XX_BUSY_TIMEOUT_MS), "BUSY stuck high after command");
+	zassert_equal(SID_ERROR_NONE,
+		      interface->xfer(interface, &client, tx_dummy, rx, sizeof(rx)));
+
+	printk("LR11xx version: hw=0x%02x type=0x%02x fw=0x%04x stat=0x%02x\n", rx[1], rx[2],
+	       ((uint16_t)rx[3] << 8) | rx[4], rx[0]);
+
+	zassert_not_equal(0xFFu, rx[1], "hw=0xFF: radio not responding");
+	zassert_equal(LR11XX_TYPE_LR1110, rx[2], "unexpected chip type");
+}
+
+#endif /* DT_NODE_EXISTS(lora_semtech_lr11xxmb1xxs) */
 
 ZTEST_SUITE(spi_bus, NULL, NULL, NULL, NULL, NULL);

--- a/tests/integration/spi/testcase.yaml
+++ b/tests/integration/spi/testcase.yaml
@@ -14,3 +14,16 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
+
+  sidewalk.test.integration.spi.lr1110:
+    sysbuild: true
+    tags: Sidewalk
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_args:
+      - SHIELD="simple_arduino_adapter;semtech_lr1110mb1xxs"


### PR DESCRIPTION
## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

Eliminating the hand-built `struct spi_config` so the pointer identity invariant the driver relies on is satisfied. +refactor.

`spi_transceive(ctx.device, &ctx.cfg, ...)` Replaced by `spi_transceive_dt(&bus_serial_spec, ...) ` -  idiomatic NCS/Zephyr pattern, which holds the same information, populated from device tree at compile time instead manually in source file.

Add test for lr1110 communication.

JIRA ticket: KRKNWK-21841

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
