### PR TITLE
samples: add nRF54LM20B BLE-only sid_end_device support

### DIFF
--- a/samples/sid_end_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
+++ b/samples/sid_end_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_POWEROFF=y
+
+# ZMS cache optimization
+CONFIG_ZMS_LOOKUP_CACHE=y
+CONFIG_ZMS_LOOKUP_CACHE_SIZE=512
+CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS=y

--- a/samples/sid_end_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/sid_end_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		state-notifier-connected = &led0;
+		state-notifier-time-sync = &led1;
+		state-notifier-registered = &led2;
+		state-notifier-working = &led3;
+	};
+};
+
+&adc {
+	status = "disabled";
+};
+
+/* Disable SPI NOR flash - not needed for BLE-only */
+&spi00 {
+	status = "disabled";
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(920)>;
+		};
+
+		slot1_partition: partition@f6000 {
+			label = "image-1";
+			reg = <0xf6000 DT_SIZE_K(920)>;
+		};
+
+		storage_partition: partition@1dc000 {
+			label = "storage";
+			reg = <0x1dc000 DT_SIZE_K(8)>;
+		};
+
+		mfg_storage: partition@1de000 {
+			label = "mfg_storage";
+			reg = <0x1de000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -81,6 +81,7 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.ble_only"
     harness: console
@@ -96,6 +97,7 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="hello.ble_only.release"
@@ -175,6 +177,7 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-dut.conf"
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="dut.ble_only"
@@ -204,6 +207,7 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_STATE_NOTIFIER=n
@@ -240,6 +244,7 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_args: FILE_SUFFIX=release
     extra_configs:
       - CONFIG_STATE_NOTIFIER=n

--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
+
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y
+
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
+
+# Ensure that the spi driver is disabled by default
+CONFIG_SPI=n
+CONFIG_SPI_NOR=n

--- a/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/sid_end_device/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
Enable BLE-only sid_end_device test targets for `nrf54lm20dk/nrf54lm20b/cpuapp`.
Add matching board and MCUboot overlay/conf files for this platform.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
