### PR TITLE
doc: add add-on v1.2.0 to compatibility matrix

### DIFF
--- a/doc/compatibility_matrix.rst
+++ b/doc/compatibility_matrix.rst
@@ -15,7 +15,18 @@ The following table demonstrates the compatibility between the nRF Connect SDK a
      - Amazon specification (Sidewalk MCU SDK version)
      - Supported platforms
      - The Amazon Sidewalk Protocol Implementation Conformance Statement (PICS)
-     - Amazon qualification status
+     - Amazon qualification status [1]_
+   * - v1.2.0
+     - v3.3.0
+     - v1.19
+     - * `nRF52840`_
+       * `nRF54L15`_
+       * `nRF54L10`_
+       * `nRF54LV10A`_
+       * `nRF54LM20A`_
+       * `nRF54LM20B`_
+     - --
+     - Compliant
    * - v1.1.0
      - v3.0.0
      - v1.19
@@ -23,59 +34,61 @@ The following table demonstrates the compatibility between the nRF Connect SDK a
        * `nRF54L15`_
        * `nRF54L10`_
      - --
-     - Planned
+     - Compliant
    * - v1.0.1
      - v3.0.0
-     - v.1.18
+     - v1.18
      - * `nRF52840`_
        * `nRF5340`_
        * `nRF54L15`_
        * `nRF54L10`_
      - --
-     - Planned
+     - Compliant
    * - v1.0.0
      - v3.0.0
-     - v.1.18
-     - * `nRF52840 DK`_
-       * `nRF5340 DK`_
-       * `nRF54L15 DK`_
+     - v1.18
+     - * `nRF52840`_
+       * `nRF5340`_
+       * `nRF54L15`_
      - --
-     - Not planned
+     - Compliant
    * - --
      - v2.9.0
      - v1.17.0
-     - * `nRF52840 DK`_
-       * `nRF5340 DK`_
-       * `nRF54L15 DK`_
+     - * `nRF52840`_
+       * `nRF5340`_
+       * `nRF54L15`_
      - * `PICS v2.9.0 - BLE only`_
        * `PICS v2.9.0`_
-     - Planned
+     - Compliant
    * - --
      - v2.8.0
      - v1.17.0
-     - * `nRF52840 DK`_
-       * `nRF5340 DK`_
-       * `nRF54L15 DK`_
+     - * `nRF52840`_
+       * `nRF5340`_
+       * `nRF54L15`_
      - --
-     - Not planned
+     - Compliant
    * - --
      - v2.7.0
      - v1.16.2
-     - * `nRF52840 DK`_
-       * `nRF5340 DK`_
+     - * `nRF52840`_
+       * `nRF5340`_
      - ---
      - Qualified/approved
    * - --
      - v2.6.0
      - v1.16.2
-     - * `nRF52840 DK`_
-       * `nRF5340 DK`_
+     - * `nRF52840`_
+       * `nRF5340`_
      - ---
      - Qualified/approved
    * - --
      - v2.5.0
      - v1.14
-     - * `nRF52840 DK`_
-       * `nRF5340 DK`_
+     - * `nRF52840`_
+       * `nRF5340`_
      - ---
      - Qualified/approved
+
+.. [1] End product qualifiable.

--- a/doc/compatibility_matrix.rst
+++ b/doc/compatibility_matrix.rst
@@ -19,76 +19,76 @@ The following table demonstrates the compatibility between the nRF Connect SDK a
    * - v1.2.0
      - v3.3.0
      - v1.19
-     - * `nRF52840`_
-       * `nRF54L15`_
-       * `nRF54L10`_
-       * `nRF54LV10A`_
-       * `nRF54LM20A`_
-       * `nRF54LM20B`_
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF54L15 <nRF54L15 Product Page_>`_
+       * `nRF54L10 <nRF54L10 Product Page_>`_
+       * `nRF54LV10A <nRF54LV10A Product Page_>`_
+       * `nRF54LM20A <nRF54LM20A Product Page_>`_
+       * `nRF54LM20B <nRF54LM20B Product Page_>`_
      - --
      - Compliant
    * - v1.1.0
      - v3.0.0
      - v1.19
-     - * `nRF52840`_
-       * `nRF54L15`_
-       * `nRF54L10`_
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF54L15 <nRF54L15 Product Page_>`_
+       * `nRF54L10 <nRF54L10 Product Page_>`_
      - --
      - Compliant
    * - v1.0.1
      - v3.0.0
      - v1.18
-     - * `nRF52840`_
-       * `nRF5340`_
-       * `nRF54L15`_
-       * `nRF54L10`_
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF5340 <nrf5340 Product Page_>`_
+       * `nRF54L15 <nRF54L15 Product Page_>`_
+       * `nRF54L10 <nRF54L10 Product Page_>`_
      - --
      - Compliant
    * - v1.0.0
      - v3.0.0
      - v1.18
-     - * `nRF52840`_
-       * `nRF5340`_
-       * `nRF54L15`_
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF5340 <nrf5340 Product Page_>`_
+       * `nRF54L15 <nRF54L15 Product Page_>`_
      - --
      - Compliant
    * - --
      - v2.9.0
      - v1.17.0
-     - * `nRF52840`_
-       * `nRF5340`_
-       * `nRF54L15`_
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF5340 <nrf5340 Product Page_>`_
+       * `nRF54L15 <nRF54L15 Product Page_>`_
      - * `PICS v2.9.0 - BLE only`_
        * `PICS v2.9.0`_
      - Compliant
    * - --
      - v2.8.0
      - v1.17.0
-     - * `nRF52840`_
-       * `nRF5340`_
-       * `nRF54L15`_
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF5340 <nrf5340 Product Page_>`_
+       * `nRF54L15 <nRF54L15 Product Page_>`_
      - --
      - Compliant
    * - --
      - v2.7.0
      - v1.16.2
-     - * `nRF52840`_
-       * `nRF5340`_
-     - ---
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF5340 <nrf5340 Product Page_>`_
+     - --
      - Qualified/approved
    * - --
      - v2.6.0
      - v1.16.2
-     - * `nRF52840`_
-       * `nRF5340`_
-     - ---
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF5340 <nrf5340 Product Page_>`_
+     - --
      - Qualified/approved
    * - --
      - v2.5.0
      - v1.14
-     - * `nRF52840`_
-       * `nRF5340`_
-     - ---
+     - * `nRF52840 <nrf52840 Product Page_>`_
+       * `nRF5340 <nrf5340 Product Page_>`_
+     - --
      - Qualified/approved
 
 .. [1] End product qualifiable.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,3 +63,9 @@ plantuml = 'java -jar /usr/local/bin/plantuml.jar'
 rst_epilog = """
 .. include:: /links.rst
 """
+
+# -- Options for sphinx_ncs_theme -------------------------------------------
+html_theme_options = {
+    "docset": "sidewalk",
+    "docsets": {},
+}

--- a/doc/links.rst
+++ b/doc/links.rst
@@ -3,10 +3,13 @@
 .. ncs links (all links need to be updated manually **right before** the targeted release)
 
 .. _nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/index.html
-.. _nrf52840: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/device_guides/nrf52/index.html
-.. _nrf5340: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
-.. _nRF54L15: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/device_guides/nrf54l/index.html
-.. _nRF54L10: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/device_guides/nrf54l/index.html
+.. _nrf52840: https://www.nordicsemi.com/Products/nRF52840
+.. _nrf5340: https://www.nordicsemi.com/Products/nRF5340
+.. _nRF54L15: https://www.nordicsemi.com/Products/nRF54L15
+.. _nRF54L10: https://www.nordicsemi.com/Products/nRF54L10
+.. _nRF54LV10A: https://www.nordicsemi.com/Products/nRF54LV10A
+.. _nRF54LM20A: https://www.nordicsemi.com/Products/nRF54LM20A
+.. _nRF54LM20B: https://www.nordicsemi.com/Products/nRF54LM20B
 .. _nrf52840 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
 .. _nrf5340 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
 .. _Thingy53: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html

--- a/doc/links.rst
+++ b/doc/links.rst
@@ -3,17 +3,11 @@
 .. ncs links (all links need to be updated manually **right before** the targeted release)
 
 .. _nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/index.html
-.. _nrf52840: https://www.nordicsemi.com/Products/nRF52840
-.. _nrf5340: https://www.nordicsemi.com/Products/nRF5340
-.. _nRF54L15: https://www.nordicsemi.com/Products/nRF54L15
-.. _nRF54L10: https://www.nordicsemi.com/Products/nRF54L10
-.. _nRF54LV10A: https://www.nordicsemi.com/Products/nRF54LV10A
-.. _nRF54LM20A: https://www.nordicsemi.com/Products/nRF54LM20A
-.. _nRF54LM20B: https://www.nordicsemi.com/Products/nRF54LM20B
 .. _nrf52840 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
 .. _nrf5340 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
 .. _Thingy53: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
-.. _nRF54L15 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/config_and_build/board_support/board_names.html
+.. _nRF54L15 DK: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/board_names.html
+.. _nrf54lm20dk: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/app_dev/board_names.html
 .. _Getting started with nRF52 Series: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/gsg_guides/nrf52_gs.html
 .. _Getting started with nRF53 Series: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/gsg_guides/nrf5340_gs.html
 .. _Getting started with nRF54L Series: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/gsg_guides/gsg_other.html
@@ -48,6 +42,14 @@
 .. _nRF Connect for VS Code: https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-VS-Code
 .. _nRF Util: https://www.nordicsemi.com/Products/Development-tools/nRF-Util
 .. _nRF Connect SDK Add-ons: https://nrfconnect.github.io/ncs-app-index/
+.. _Thingy53 Product Page: https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-53
+.. _nrf52840 Product Page: https://www.nordicsemi.com/Products/nRF52840
+.. _nrf5340 Product Page: https://www.nordicsemi.com/Products/nRF5340
+.. _nRF54L15 Product Page: https://www.nordicsemi.com/Products/nRF54L15
+.. _nRF54L10 Product Page: https://www.nordicsemi.com/Products/nRF54L10
+.. _nRF54LV10A Product Page: https://www.nordicsemi.com/Products/nRF54LV10A
+.. _nRF54LM20A Product Page: https://www.nordicsemi.com/Products/nRF54LM20A
+.. _nRF54LM20B Product Page: https://www.nordicsemi.com/Products/nRF54LM20B
 
 .. github.com
 

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -5,7 +5,7 @@ MarkupSafe==1.1.1
 Pygments>=2.15.0
 PyYAML>=5.4.1
 sphinx==4.3.0
-sphinx-ncs-theme==0.6.2
+sphinx-ncs-theme<1.1
 sphinx-rtd-theme==0.5.2
 sphinx-tabs==3.1.0
 sphinx-togglebutton==0.3.2

--- a/doc/samples/sid_end_device.rst
+++ b/doc/samples/sid_end_device.rst
@@ -18,24 +18,42 @@ Requirements
 
 This sample supports the following development kits:
 
-+--------------------------------------+----------+-------------------+-------------------------------------+
-| Hardware platforms                   | PCA      | Board name        | Build target                        |
-+======================================+==========+===================+=====================================+
-| nRF52840 DK                          | PCA10056 | `nrf52840dk`_     | ``nrf52840dk/nrf52840``             |
-+--------------------------------------+----------+-------------------+-------------------------------------+
-| nRF5340 DK                           | PCA10095 | `nrf5340dk`_      | ``nrf5340dk/nrf5340/cpuapp``        |
-+--------------------------------------+----------+-------------------+-------------------------------------+
-| Thingy53                             | PCA20053 | `thingy53`_       | ``thingy53/nrf5340/cpuapp``         |
-+--------------------------------------+----------+-------------------+-------------------------------------+
-| nRF54L15 DK                          | PCA10156 | `nrf54l15dk`_     | ``nrf54l15dk/nrf54l15/cpuapp``      |
-|                                      |          |                   | ``nrf54l15dk/nrf54l15/cpuapp/ns``   |
-+--------------------------------------+----------+-------------------+-------------------------------------+
-| nRF54L10 (emulating on nRF54L15 DK)  | PCA10156 | `nrf54l15dk`_     | ``nrf54l15dk/nrf54l10/cpuapp``      |
-+--------------------------------------+----------+-------------------+-------------------------------------+
-| nRF54LV10 DK                         | PCA10188 | `nrf54lv10dk`_    | ``nrf54lv10dk/nrf54lv10a/cpuapp``   |
-+--------------------------------------+----------+-------------------+-------------------------------------+
-| nRF54LM20 DK                         | PCA10184 | `nrf54lm20dk`_    | ``nrf54lm20dk/nrf54lm20a/cpuapp``   |
-+--------------------------------------+----------+-------------------+-------------------------------------+
+.. list-table::
+   :header-rows: 1
+
+   * - Hardware platforms
+     - PCA
+     - Board name
+     - Build target
+   * - `nRF52840 DK <nrf52840 Product Page_>`_
+     - PCA10056
+     - `nrf52840dk`_
+     - ``nrf52840dk/nrf52840``
+   * - `nRF5340 DK <nrf5340 Product Page_>`_
+     - PCA10095
+     - `nrf5340dk`_
+     - ``nrf5340dk/nrf5340/cpuapp``
+   * - `Thingy:53 <Thingy53 Product Page_>`_
+     - PCA20053
+     - `thingy53_nrf5340`_
+     - ``thingy53/nrf5340/cpuapp``
+   * - `nRF54L15 DK <nRF54L15 Product Page_>`_
+     - PCA10156
+     - `nrf54l15dk`_
+     - | ``nrf54l15dk/nrf54l15/cpuapp``
+       | ``nrf54l15dk/nrf54l15/cpuapp/ns``
+   * - `nRF54L10 (emulating on nRF54L15 DK) <nRF54L10 Product Page_>`_
+     - PCA10156
+     - `nrf54l15dk`_
+     - ``nrf54l15dk/nrf54l10/cpuapp``
+   * - `nRF54LV10 DK <nRF54LV10A Product Page_>`_
+     - PCA10188
+     - `nrf54lv10dk`_
+     - ``nrf54lv10dk/nrf54lv10a/cpuapp``
+   * - `nRF54LM20 DK <nRF54LM20A Product Page_>`_
+     - PCA10184
+     - `nrf54lm20dk`_
+     - ``nrf54lm20dk/nrf54lm20a/cpuapp``
 
 To run the sample in the Bluetooth LE link mode, you only need the development kit.
 However, if you want to run the sample with LoRa or FSK configuration, you also need the LoRa radio module.


### PR DESCRIPTION
Add a new row for sdk-sidewalk Add-on v1.2.0. The release extends supported platforms with three new nRF54L Series SoCs: nRF54LV10A, nRF54LM20A, and nRF54LM20B.

Additionally, this commit normalize the qualification-status column to "Compliant" for releases that are spec-compliant but not formally Amazon-qualified by Nordic.

Fix a "v.1.18" typo in the Sidewalk MCU SDK version column.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
