### PR TITLE
doc: add location init logs

### DIFF
--- a/doc/samples/variants/dut.rst
+++ b/doc/samples/variants/dut.rst
@@ -141,8 +141,12 @@ Testing Location Services
 
       uart:~$ location init
       <inf> location_shell_events: location_event_init returned 0
+      <inf> location_shell_events: loc send result: 0
+      <inf> location_shell_events: loc effort mode: 0
+      <inf> location_shell_events: loc link type: 0
 
    You should see a log message with a success status.
+   It may take a few seconds to get location stats (effort mode, link type).
 
 #. Send the location depending on the protocol used:
 


### PR DESCRIPTION
Show location module status logs next to
location event init status logs.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
