### PR TITLE
GHA: nrf upmerge manual only and PR documentation build

### DIFF
--- a/.github/workflows/documentation_build.yml
+++ b/.github/workflows/documentation_build.yml
@@ -1,0 +1,59 @@
+name: Build documentation
+
+on:
+  workflow_dispatch:
+    inputs:
+      documentation_tag:
+        type: string
+        required: false
+        default: "latest"
+        description: "Label stamped into built documentation"
+
+  workflow_call:
+    inputs:
+      documentation_tag:
+        type: string
+        required: true
+        default: "latest"
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-24.04
+    env:
+      ARCHIVE: "addon-sidewalk_${{ inputs.documentation_tag }}.zip"
+    container:
+      image: ghcr.io/nrfconnect/sdk-sidewalk:main
+      options: --cpus 2
+    defaults:
+      run:
+        shell: nrfutil toolchain-manager launch --install-dir /root/ncs bash -- {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: sidewalk
+
+      - name: Build documentation
+        run: |
+          cd sidewalk/doc
+          ./build_local.sh
+
+          cp custom.properties build/html
+          sed -i 's/__VERSION__/'"${{ inputs.documentation_tag }}"'/g' build/html/custom.properties
+
+          cp tags.yml build/html
+          sed -i 's/__VERSION__/'"${{ inputs.documentation_tag }}"'/g' build/html/tags.yml
+
+          cd build/html
+          zip -rq "${{ env.ARCHIVE }}" .
+          mv "${{ env.ARCHIVE }}" /workdir/${{ env.ARCHIVE }}
+          ls -lah /workdir
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: /workdir/${{ env.ARCHIVE }}

--- a/.github/workflows/nrf-upmerge-pr.yml
+++ b/.github/workflows/nrf-upmerge-pr.yml
@@ -1,8 +1,6 @@
 name: NRF upmerge
 
 on:
-  schedule:
-    - cron: "0 0 * * 0"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/on-pr_documentation.yml
+++ b/.github/workflows/on-pr_documentation.yml
@@ -1,0 +1,63 @@
+name: Build documentation on PR
+
+on:
+  pull_request:
+    paths:
+      - 'doc/**'
+
+concurrency:
+  group: docs-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build_documentation:
+    uses: ./.github/workflows/documentation_build.yml
+    with:
+      documentation_tag: pr-${{ github.event.pull_request.number }}
+
+  post_pr_comment:
+    name: Post documentation build result
+    needs: build_documentation
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Documentation build summary
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          {
+            echo "### Documentation build"
+            echo ""
+            echo "| Resource | Link |"
+            echo "| --- | --- |"
+            echo "| Workflow run | [${{ github.workflow }} #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| Documentation (zip) | [Download \`documentation\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) — unzip and open \`index.html\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Find documentation comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- documentation-build -->"
+
+      - name: Update documentation comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- documentation-build -->
+            ### Documentation build
+
+            Sphinx documentation built successfully for this PR.
+
+            | Resource | Link |
+            | --- | --- |
+            | Workflow run | [${{ github.workflow }} #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+            | Documentation (zip) | [Download `documentation`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) — unzip and open `index.html` |

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -29,67 +29,44 @@ on:
         default: true
 
 jobs:
-  Publish_Documentation:
-    env:
-      ARCHIVE: "addon-sidewalk_${{inputs.documentation_tag}}.zip"
+  build:
+    uses: ./.github/workflows/documentation_build.yml
+    with:
+      documentation_tag: ${{ inputs.documentation_tag }}
 
+  publish:
+    name: Publish documentation to Zoomin
+    needs: build
+    if: inputs.publish_to_dev || inputs.publish_to_prod
     runs-on: ubuntu-24.04
-    container:
-      image: ghcr.io/nrfconnect/sdk-sidewalk:main
-      options: --cpus 2
-    defaults:
-      run:
-        shell: nrfutil toolchain-manager launch --install-dir /root/ncs bash -- {0}
+    env:
+      ARCHIVE: "addon-sidewalk_${{ inputs.documentation_tag }}.zip"
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          path: sidewalk
-
-      - name: Build documentation
-        run: |
-          cd sidewalk/doc
-          ./build_local.sh
-
-          cp custom.properties build/html
-          sed -i 's/__VERSION__/'"${{inputs.documentation_tag}}"'/g' build/html/custom.properties
-
-          cp tags.yml build/html
-          sed -i 's/__VERSION__/'"${{inputs.documentation_tag}}"'/g' build/html/tags.yml
-
-          cd build/html
-          zip -rq "${{env.ARCHIVE}}" .
-          mv "${{env.ARCHIVE}}" /workdir/${{env.ARCHIVE}}
-          ls -lah /workdir
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+      - name: Download documentation archive
+        uses: actions/download-artifact@v4
         with:
           name: documentation
-          path: |
-            /workdir/${{env.ARCHIVE}}
 
       - name: Prepare Key
         run: |
-          mkdir -p /root/.ssh
-          ssh-keyscan ${{ vars.NCS_ZOOMIN_SERVER }} >> /root/.ssh/known_hosts
+          mkdir -p ~/.ssh
+          ssh-keyscan ${{ vars.NCS_ZOOMIN_SERVER }} >> ~/.ssh/known_hosts
           echo "${{ secrets.NCS_ZOOMIN_KEY }}" > zoomin_key
           chmod 600 zoomin_key
 
       - name: Publish documentation - dev
-        if: ${{inputs.publish_to_dev}}
+        if: inputs.publish_to_dev
         run: |
-          sftp -v -i zoomin_key ${{vars.NCS_ZOOMIN_USER}}@${{ vars.NCS_ZOOMIN_SERVER }} <<EOF
-            cd ${{ vars.NCS_ZOOMIN_DEPLOY_DEV_PATH}}
-            put /workdir/${{env.ARCHIVE}}
+          sftp -v -i zoomin_key ${{ vars.NCS_ZOOMIN_USER }}@${{ vars.NCS_ZOOMIN_SERVER }} <<EOF
+            cd ${{ vars.NCS_ZOOMIN_DEPLOY_DEV_PATH }}
+            put ${{ env.ARCHIVE }}
           EOF
 
       - name: Publish documentation - prod
-        if: ${{inputs.publish_to_prod}}
+        if: inputs.publish_to_prod
         run: |
-          sftp -v -i zoomin_key ${{vars.NCS_ZOOMIN_USER}}@${{ vars.NCS_ZOOMIN_SERVER }} <<EOF
-            cd ${{ vars.NCS_ZOOMIN_DEPLOY_PROD_PATH}}
-            put /workdir/${{env.ARCHIVE}}
+          sftp -v -i zoomin_key ${{ vars.NCS_ZOOMIN_USER }}@${{ vars.NCS_ZOOMIN_SERVER }} <<EOF
+            cd ${{ vars.NCS_ZOOMIN_DEPLOY_PROD_PATH }}
+            put ${{ env.ARCHIVE }}
           EOF


### PR DESCRIPTION
## Summary

- **NRF upmerge:** Remove the weekly cron from `nrf-upmerge-pr.yml`; keep `workflow_dispatch` for manual manifest updates.
- **Documentation (DRY):** Add reusable `documentation_build.yml` (Sphinx build + artifacts). Refactor `publish_documentation.yml` to call it before Zoomin SFTP.
- **PR doc checks:** Add `on-pr_documentation.yml` — runs when `doc/**` changes on a pull request. Builds only (no Zoomin publish). Fails the check if Sphinx fails (errors in workflow logs). On success, posts a PR comment with links to the workflow run, the `documentation-html` artifact, and an optional GitHub Pages preview (`gh-pages` / Pages must be configured).

## Test plan

- [ ] Confirm **NRF upmerge** has **Run workflow** only (no schedule) after merge.
- [ ] Open or update a PR that touches `doc/**` and confirm **Build documentation on PR** runs and passes.
- [ ] Confirm **Publish latest documentation** / tag publish still work via refactored `publish_documentation.yml`.
- [ ] Optional: verify Pages preview URL in the PR comment (same-repo PRs only).