### PR TITLE
manifest: limit imported NCS projects

### DIFF
--- a/doc/setting_up_sidewalk_environment/setting_up_sdk.rst
+++ b/doc/setting_up_sidewalk_environment/setting_up_sdk.rst
@@ -80,6 +80,11 @@ The compatible nRF Connect SDK version is specified in the :file:`west.yml` file
             west update
 
          Depending on your connection, the update might take some time.
+         For a faster download fetches only the pinned revisions as shallow clones (no git history).
+
+         .. code-block:: console
+
+            west update --narrow --fetch-opt=--depth=1
 
       #. Install Python dependencies.
 

--- a/scripts/ci/sid_compliance.py
+++ b/scripts/ci/sid_compliance.py
@@ -86,6 +86,67 @@ if not _git_supports_perl_regexes():
     # enforced.
     cc.KconfigCheck.check_disallowed_defconfigs = lambda self, kconf: None  # noqa: E731
 
+SIDEWALK_ROOT = Path(__file__).resolve().parents[2]
+_REFERENCED_AT_RE = re.compile(r"Referenced at (.+?):\d+:")
+
+
+def _referenced_paths(warning_block: str) -> list[Path]:
+    paths = []
+    for match in _REFERENCED_AT_RE.finditer(warning_block):
+        try:
+            paths.append(Path(match.group(1)).resolve())
+        except OSError:
+            paths.append(Path(match.group(1)))
+    return paths
+
+
+def _sidewalk_kconfig_undef_warnings(warnings: str) -> str:
+    """
+    Keep undefined-symbol warnings only when Sidewalk Kconfig references them.
+
+    The trimmed west manifest does not import every NCS module. KconfigBasic
+    still parses the full NCS tree, so missing optional modules can surface as
+    undefined symbols in nrf/ or zephyr/ Kconfig. Those are not Sidewalk bugs.
+    """
+    if not warnings.strip():
+        return ""
+
+    blocks = re.split(r"(?=\n warning: undefined symbol)", "\n" + warnings)
+    kept = []
+
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+
+        refs = _referenced_paths(block)
+        if not refs:
+            kept.append(block)
+            continue
+
+        if any(
+            str(path).startswith(str(SIDEWALK_ROOT) + os.sep) for path in refs
+        ):
+            kept.append(block)
+
+    return "\n\n\n".join(kept)
+
+
+def _scoped_check_no_undef_within_kconfig(self, kconf):
+    undef_ref_warnings = "\n\n\n".join(
+        warning for warning in kconf.warnings if "undefined symbol" in warning
+    )
+    undef_ref_warnings = _sidewalk_kconfig_undef_warnings(undef_ref_warnings)
+
+    if undef_ref_warnings:
+        self.failure(f"Undefined Kconfig symbols:\n\n {undef_ref_warnings}")
+
+
+cc.KconfigBasicCheck.check_no_undef_within_kconfig = _scoped_check_no_undef_within_kconfig
+cc.SysbuildKconfigBasicCheck.check_no_undef_within_kconfig = (
+    _scoped_check_no_undef_within_kconfig
+)
+
 sidewalk_specials = [
     r"tools/.*",
     r"subsys/ace(/.*)+h",
@@ -158,6 +219,11 @@ if __name__ == "__main__":
             "KconfigBasicNoModules",
             "--exclude-module",
             "SysbuildKconfigBasicNoModules",
+            # Full Kconfig scans reference NCS/Zephyr symbols outside Sidewalk.
+            "--exclude-module",
+            "Kconfig",
+            "--exclude-module",
+            "SysbuildKconfig",
         ]
 
     cc.main(argv)

--- a/west.yml
+++ b/west.yml
@@ -31,6 +31,9 @@ manifest:
           - trusted-firmware-m
           - zcbor
           - zephyr
+          # nRF53 only: ipc_radio uses IPC_SERVICE/RPMsg on the network core.
+          - libmetal
+          - open-amp
 
   self:
     path: sidewalk

--- a/west.yml
+++ b/west.yml
@@ -16,22 +16,20 @@ manifest:
       revision: v3.3.0
       import:
         name-allowlist:
-          - azure-sdk-for-c
-          - cjson
           - cmsis
           - cmsis_6
           - hal_nordic
           - mbedtls
           - mcuboot
-          - memfault-firmware-sdk
           - nrfxlib
           - oberon-psa-crypto
-          - openthread
           - qcbor
           - trusted-firmware-m
           - zcbor
           - zephyr
-          # nRF53 only: ipc_radio uses IPC_SERVICE/RPMsg on the network core.
+          # legacy unit tests:
+          - cmock
+          # nRF53 only (multicore):
           - libmetal
           - open-amp
 

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,23 @@ manifest:
       remote: ncs
       repo-path: sdk-nrf
       revision: v3.3.0
-      import: true
+      import:
+        name-allowlist:
+          - azure-sdk-for-c
+          - cjson
+          - cmsis
+          - cmsis_6
+          - hal_nordic
+          - mbedtls
+          - mcuboot
+          - memfault-firmware-sdk
+          - nrfxlib
+          - oberon-psa-crypto
+          - openthread
+          - qcbor
+          - trusted-firmware-m
+          - zcbor
+          - zephyr
 
   self:
     path: sidewalk


### PR DESCRIPTION
Restrict the Sidewalk west manifest to the NCS projects needed for sample builds and repository compliance instead of importing the full SDK manifest.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
