### PR TITLE
GHA: broaden PR documentation workflow path filters

### DIFF
--- a/.github/workflows/on-pr_documentation.yml
+++ b/.github/workflows/on-pr_documentation.yml
@@ -3,7 +3,8 @@ name: Build documentation on PR
 on:
   pull_request:
     paths:
-      - 'doc/**'
+      - '**/doc/**'
+      - '**/*.rst'
 
 concurrency:
   group: docs-pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Trigger documentation build on changes in any doc directory, including board doc trees, and on any .rst file in the repository.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf52
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [ ] Change has been tested.
- [x] Tests were updated (if applicable).
