### PR TITLE
sal: sid_pal: store keys in KMU instead of trusted storage

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -198,9 +198,8 @@ config SIDEWALK_MFG_STORAGE_SUPPORT_HEX_v7
 	  and will be supported after enabling this configuration.
 
 config SIDEWALK_CRYPTO_PSA_KEY_STORAGE
-	bool "PSA crypto storage for persistent Sidewalk keys [EXPERIMENTAL]"
+	bool "PSA crypto storage for persistent Sidewalk keys"
 	default SIDEWALK
-	select EXPERIMENTAL
 	help
 	  Use secure key storage for persistent Sidewalk keys.
 	  Once you flash the firmware with this config enabled,
@@ -220,7 +219,7 @@ config SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU_SLOT_START
 	int "Start of the Sidewalk KMU slot range"
 	depends on SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU
 	range 0 173
-	default 128
+	default 173
 	help
 	  First KMU slot used by Sidewalk persistent keys. Sidewalk reserves five
 	  consecutive key IDs starting from this value. Some keys span multiple

--- a/Kconfig
+++ b/Kconfig
@@ -207,6 +207,25 @@ config SIDEWALK_CRYPTO_PSA_KEY_STORAGE
 	  it must be enabled in every subsequent build.
 	  Otherwise, the keys will not be found and Sidewalk will not start.
 
+config SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU
+	bool "Store persistent Sidewalk keys in KMU"
+	depends on SIDEWALK_CRYPTO_PSA_KEY_STORAGE
+	depends on CRACEN_LIB_KMU
+	default y
+	help
+	  Store persistent Sidewalk PSA keys in the CRACEN Key Management Unit (KMU)
+	  instead of the default PSA trusted storage backend.
+
+config SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU_SLOT_START
+	int "Start of the Sidewalk KMU slot range"
+	depends on SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU
+	range 0 173
+	default 128
+	help
+	  First KMU slot used by Sidewalk persistent keys. Sidewalk reserves five
+	  consecutive key IDs starting from this value. Some keys span multiple
+	  KMU slots, so the range occupies seven consecutive KMU slots.
+
 config SIDEWALK_USE_PREBUILTS
 	bool "Use prebuilt Sidewalk libraries"
 	default y

--- a/doc/releases_and_migration/migration_guide_addon_changelog.rst
+++ b/doc/releases_and_migration/migration_guide_addon_changelog.rst
@@ -32,6 +32,22 @@ Perform a pristine build of the application after adding this override.
 .. note::
    Use ED25519 for new designs on nRF54L Series platforms because of its shorter verification time and smaller key size.
 
+Persistent Sidewalk keys in KMU
+*******************************
+
+This release stores persistent Sidewalk cryptographic keys in the Key Management Unit (KMU) by default on supported nRF54L Series platforms.
+The feature is controlled by the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU`` Kconfig option.
+
+If you update devices that already have keys stored by an earlier firmware version, set ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU=n`` to keep the keys accessible.
+Switching an already-provisioned product from the default PSA trusted storage backend to KMU changes the PSA key IDs used by Sidewalk, as well as the storage location, so existing keys will not be found.
+
+For new products, use the KMU default and make sure that your application does not use the same KMU slots for other keys.
+Sidewalk starts at ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU_SLOT_START`` and reserves seven consecutive KMU slots:
+
+* Two slots for the manufacturing ED25519 private key.
+* Two slots for the manufacturing secp256r1 private key.
+* One slot each for the WAN master, app key, and device-to-device AES keys.
+
 Removed platform support
 ************************
 

--- a/doc/releases_and_migration/migration_guide_addon_changelog.rst
+++ b/doc/releases_and_migration/migration_guide_addon_changelog.rst
@@ -35,14 +35,15 @@ Perform a pristine build of the application after adding this override.
 Persistent Sidewalk keys in KMU
 *******************************
 
-This release stores persistent Sidewalk cryptographic keys in the Key Management Unit (KMU) by default on supported nRF54L Series platforms.
-The feature is controlled by the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU`` Kconfig option.
+Persistent Sidewalk cryptographic keys are now stored in the Key Management Unit (KMU) by default on supported nRF54L Series platforms.
+Use the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU`` Kconfig option to control this feature.
 
 If you update devices that already have keys stored by an earlier firmware version, set ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU=n`` to keep the keys accessible.
-Switching an already-provisioned product from the default PSA trusted storage backend to KMU changes the PSA key IDs used by Sidewalk, as well as the storage location, so existing keys will not be found.
+Switching a provisioned product from the PSA trusted storage to KMU changes both the storage location and the PSA key IDs, so Sidewalk cannot find the existing keys.
 
-For new products, use the KMU default and make sure that your application does not use the same KMU slots for other keys.
-Sidewalk starts at ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU_SLOT_START`` and reserves seven consecutive KMU slots:
+For new products, use the KMU default.
+Make sure that your application does not use the same KMU slots for other keys.
+Sidewalk starts at the slot defined by the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU_SLOT_START`` Kconfig option and reserves seven consecutive KMU slots:
 
 * Two slots for the manufacturing ED25519 private key.
 * Two slots for the manufacturing secp256r1 private key.

--- a/doc/releases_and_migration/release_notes_addon_changelog.rst
+++ b/doc/releases_and_migration/release_notes_addon_changelog.rst
@@ -25,6 +25,8 @@ Changelog
     On the nRF54L Series platforms, the bootloader now uses ED25519 instead of RSA.
     This reduces MCUboot boot time compared to RSA-based verification.
   * MCUboot configuration to align with NCS recommendations: picolibc and link-time optimization (LTO).
+  * Persistent Sidewalk key storage to use Key Management Unit (KMU) by default.
+    Use ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU=n`` to keep the default settings-based PSA trusted storage backend.
 
 * Removed:
 

--- a/doc/releases_and_migration/release_notes_addon_changelog.rst
+++ b/doc/releases_and_migration/release_notes_addon_changelog.rst
@@ -26,7 +26,7 @@ Changelog
     This reduces MCUboot boot time compared to RSA-based verification.
   * MCUboot configuration to align with NCS recommendations: picolibc and link-time optimization (LTO).
   * Persistent Sidewalk key storage to use Key Management Unit (KMU) by default.
-    Use ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU=n`` to keep the default settings-based PSA trusted storage backend.
+    Set the Kconfig option ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU=n`` to keep the default settings-based PSA trusted storage backend.
 
 * Removed:
 

--- a/doc/samples/sid_end_device.rst
+++ b/doc/samples/sid_end_device.rst
@@ -149,15 +149,15 @@ Secure Key Storage support
 The Sidewalk Platform Abstraction Layer for nRF Connect SDK supports a trusted storage mechanism to securely store non-volatile Sidewalk keys.
 The feature is enabled by default with the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE`` Kconfig option.
 
-The trusted storage can be configured to store the keys in one of the following locations:
+Configure the trusted storage to store the keys in one of the following locations:
 
-* Key Management Unit (KMU), enabled by default with the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU`` Kconfig option.
-* Settings partition, otherwise.
+* Key Management Unit (KMU) - Enabled by default with the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU`` Kconfig option.
+* Settings partition - Used when the KMU option is disabled.
 
 .. note::
 
-   Once keys are moved to the trusted storage, it is impossible to read them back and move into MFG storage.
-   Therefore, do not update your firmware to versions that do not support the trusted storage, or use a different storage backend.
+   Once keys are moved to the trusted storage, you cannot read them back and move into MFG storage.
+   For this reason, do not update your firmware to versions that do not support the trusted storage, or use a different storage backend.
 
 Device Firmware Upgrade support
 ===============================

--- a/doc/samples/sid_end_device.rst
+++ b/doc/samples/sid_end_device.rst
@@ -146,18 +146,18 @@ For example:
 Secure Key Storage support
 ==========================
 
-The Sidewalk Platform Abstraction Layer for nRF Connect SDK supports a trusted storage mechanism for non-volatile Sidewalk keys, ensuring they are stored persistently and confidentially.
+The Sidewalk Platform Abstraction Layer for nRF Connect SDK supports a trusted storage mechanism to securely store non-volatile Sidewalk keys.
 The feature is enabled by default with the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE`` Kconfig option.
+
+The trusted storage can be configured to store the keys in one of the following locations:
+
+* Key Management Unit (KMU), enabled by default with the ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU`` Kconfig option.
+* Settings partition, otherwise.
 
 .. note::
 
-   Once keys are moved to trusted storage, it is impossible to retrieve them back into MFG storage.
-   Therefore, you must not update your firmware to versions that do not support trusted storage for non-volatile Sidewalk keys.
-
-.. warning::
-  Once keys are moved to trusted storage, you MUST NOT change the settings backend. Otherwise, you will lose data, and the device will become inoperable!
-
-  E.g. when ``CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE`` is enabled you MUST NOT switch from `CONFIG_NVS <https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/storage/nvs/nvs.html>`_ to `CONFIG_ZMS <https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/storage/zms/zms.html>`_.
+   Once keys are moved to the trusted storage, it is impossible to read them back and move into MFG storage.
+   Therefore, do not update your firmware to versions that do not support the trusted storage, or use a different storage backend.
 
 Device Firmware Upgrade support
 ===============================

--- a/subsys/sal/sid_pal/include/sid_crypto_keys.h
+++ b/subsys/sal/sid_pal/include/sid_crypto_keys.h
@@ -9,20 +9,41 @@
 
 #include <psa/crypto.h>
 
-#define SID_CRYPTO_KEYS_ID_IS_SIDEWALK_KEY(_id)                                                    \
-	(PSA_KEY_ID_USER_MIN <= _id && _id < SID_CRYPTO_KEY_ID_LAST)
+#if defined(CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU)
+#include <cracen_psa_kmu.h>
+
+#define SID_CRYPTO_KMU_KEY_ID(_offset)                                                             \
+	PSA_KEY_HANDLE_FROM_CRACEN_KMU_SLOT(                                                       \
+		CRACEN_KMU_KEY_USAGE_SCHEME_RAW,                                                   \
+		CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU_SLOT_START + (_offset))
+#endif /* CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU */
 
 /**
  * @brief Persistent psa key ids used in Sidewalk.
  */
 typedef enum {
+#if defined(CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU)
+	SID_CRYPTO_MFG_ED25519_PRIV_KEY_ID = SID_CRYPTO_KMU_KEY_ID(0), /* occupies 2 KMU slots */
+	SID_CRYPTO_MFG_SECP_256R1_PRIV_KEY_ID = SID_CRYPTO_KMU_KEY_ID(2), /* occupies 2 KMU slots */
+	SID_CRYPTO_KV_WAN_MASTER_KEY_ID = SID_CRYPTO_KMU_KEY_ID(4),
+	SID_CRYPTO_KV_APP_KEY_KEY_ID = SID_CRYPTO_KMU_KEY_ID(5),
+	SID_CRYPTO_KV_D2D_KEY_ID = SID_CRYPTO_KMU_KEY_ID(6),
+	SID_CRYPTO_KEY_ID_LAST
+#else
 	SID_CRYPTO_MFG_ED25519_PRIV_KEY_ID = PSA_KEY_ID_USER_MIN,
 	SID_CRYPTO_MFG_SECP_256R1_PRIV_KEY_ID,
 	SID_CRYPTO_KV_WAN_MASTER_KEY_ID,
 	SID_CRYPTO_KV_APP_KEY_KEY_ID,
 	SID_CRYPTO_KV_D2D_KEY_ID,
 	SID_CRYPTO_KEY_ID_LAST
+#endif /* CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU */
 } sid_crypto_key_id_t;
+
+#define SID_CRYPTO_KEYS_ID_IS_SIDEWALK_KEY(_id)                                                    \
+	((_id) == SID_CRYPTO_MFG_ED25519_PRIV_KEY_ID ||                                            \
+	 (_id) == SID_CRYPTO_MFG_SECP_256R1_PRIV_KEY_ID ||                                         \
+	 (_id) == SID_CRYPTO_KV_WAN_MASTER_KEY_ID || (_id) == SID_CRYPTO_KV_APP_KEY_KEY_ID ||      \
+	 (_id) == SID_CRYPTO_KV_D2D_KEY_ID)
 
 /**
  * @brief Init secure key storage for Sidewalk keys.

--- a/subsys/sal/sid_pal/src/sid_crypto_keys.c
+++ b/subsys/sal/sid_pal/src/sid_crypto_keys.c
@@ -70,7 +70,13 @@ static void sid_crypto_keys_attributes_set(sid_crypto_key_id_t sid_key_id,
 	psa_set_key_type(attr, type);
 	psa_set_key_bits(attr, key_bits);
 
+#if defined(CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU)
+	psa_set_key_lifetime(attr, PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(
+					   PSA_KEY_PERSISTENCE_DEFAULT,
+					   PSA_KEY_LOCATION_CRACEN_KMU));
+#else
 	psa_set_key_lifetime(attr, PSA_KEY_LIFETIME_PERSISTENT);
+#endif /* CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU */
 	psa_set_key_id(attr, sid_key_id);
 }
 

--- a/subsys/sal/sid_pal/src/sid_crypto_keys.c
+++ b/subsys/sal/sid_pal/src/sid_crypto_keys.c
@@ -41,13 +41,13 @@ static void sid_crypto_keys_attributes_set(sid_crypto_key_id_t sid_key_id,
 
 	switch (sid_key_id) {
 	case SID_CRYPTO_MFG_ED25519_PRIV_KEY_ID:
-		usage_flags = PSA_KEY_USAGE_SIGN_HASH;
+		usage_flags = PSA_KEY_USAGE_SIGN_MESSAGE;
 		alg = PSA_ALG_PURE_EDDSA;
 		type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS);
 		key_bits = 255;
 		break;
 	case SID_CRYPTO_MFG_SECP_256R1_PRIV_KEY_ID:
-		usage_flags = PSA_KEY_USAGE_SIGN_HASH;
+		usage_flags = PSA_KEY_USAGE_SIGN_MESSAGE;
 		alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
 		type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
 		key_bits = 256;

--- a/tests/integration/crypto_keys/Kconfig
+++ b/tests/integration/crypto_keys/Kconfig
@@ -21,6 +21,14 @@ config SIDEWALK_SETTINGS_UTILS
 config SIDEWALK_CRYPTO_PSA_KEY_STORAGE
 	default y
 
+config SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU
+	bool "Store persistent Sidewalk keys in nRF54L KMU"
+	default y
+
+config SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU_SLOT_START
+	depends on SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU
+	default 173
+
 config SIDEWALK_CRYPTO_LOG_LEVEL
 	default 0
 

--- a/tests/integration/crypto_keys/src/main.c
+++ b/tests/integration/crypto_keys/src/main.c
@@ -9,13 +9,165 @@
 #include <sid_pal_storage_kv_ifc.h>
 
 #include <errno.h>
+#include <string.h>
 
-#define TEST_SYMMETRIC_KEY_SIZE (16)
-#define TEST_ECC_PRIVATE_KEY_SIZE (255)
-#define TEST_ECC_PUBLIC_KEY_SIZE (32)
+#define TEST_AES_KEY_SIZE 16
+#define TEST_ED25519_KEY_SIZE 32
+#define TEST_SECP256R1_KEY_SIZE 32
+#define TEST_ED25519_PUBLIC_KEY_SIZE 32
+#define TEST_SECP256R1_PUBLIC_KEY_SIZE 65
 
 static psa_key_id_t test_key_id = SID_CRYPTO_KV_APP_KEY_KEY_ID;
 static psa_key_id_t test_key_ecc_id = SID_CRYPTO_MFG_ED25519_PRIV_KEY_ID;
+
+struct test_key_spec {
+	psa_key_id_t id;
+	const uint8_t *key_data;
+	size_t key_data_size;
+	psa_key_type_t key_type;
+	psa_algorithm_t alg;
+	bool is_symmetric;
+	size_t public_key_size;
+};
+
+static const uint8_t test_message[] = "Sidewalk crypto key test message";
+
+static const uint8_t test_ed25519_key[TEST_ED25519_KEY_SIZE] = {
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+	0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+	0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+};
+
+static const uint8_t test_secp256r1_key[TEST_SECP256R1_KEY_SIZE] = {
+	0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18, 0x17, 0x16, 0x15,
+	0x14, 0x13, 0x12, 0x11, 0x10, 0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A,
+	0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x01,
+};
+
+static const uint8_t test_wan_key[TEST_AES_KEY_SIZE] = { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5,
+							 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB,
+							 0xAC, 0xAD, 0xAE, 0xAF };
+
+static const uint8_t test_app_key[TEST_AES_KEY_SIZE] = { 0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5,
+							 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB,
+							 0xBC, 0xBD, 0xBE, 0xBF };
+
+static const uint8_t test_d2d_key[TEST_AES_KEY_SIZE] = { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5,
+							 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB,
+							 0xCC, 0xCD, 0xCE, 0xCF };
+
+static const struct test_key_spec import_key_specs[] = {
+	{
+		.id = SID_CRYPTO_MFG_ED25519_PRIV_KEY_ID,
+		.key_data = test_ed25519_key,
+		.key_data_size = sizeof(test_ed25519_key),
+		.key_type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS),
+		.alg = PSA_ALG_PURE_EDDSA,
+		.is_symmetric = false,
+		.public_key_size = TEST_ED25519_PUBLIC_KEY_SIZE,
+	},
+	{
+		.id = SID_CRYPTO_MFG_SECP_256R1_PRIV_KEY_ID,
+		.key_data = test_secp256r1_key,
+		.key_data_size = sizeof(test_secp256r1_key),
+		.key_type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1),
+		.alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256),
+		.is_symmetric = false,
+		.public_key_size = TEST_SECP256R1_PUBLIC_KEY_SIZE,
+	},
+	{
+		.id = SID_CRYPTO_KV_WAN_MASTER_KEY_ID,
+		.key_data = test_wan_key,
+		.key_data_size = sizeof(test_wan_key),
+		.key_type = PSA_KEY_TYPE_AES,
+		.alg = PSA_ALG_CMAC,
+		.is_symmetric = true,
+	},
+	{
+		.id = SID_CRYPTO_KV_APP_KEY_KEY_ID,
+		.key_data = test_app_key,
+		.key_data_size = sizeof(test_app_key),
+		.key_type = PSA_KEY_TYPE_AES,
+		.alg = PSA_ALG_CMAC,
+		.is_symmetric = true,
+	},
+	{
+		.id = SID_CRYPTO_KV_D2D_KEY_ID,
+		.key_data = test_d2d_key,
+		.key_data_size = sizeof(test_d2d_key),
+		.key_type = PSA_KEY_TYPE_AES,
+		.alg = PSA_ALG_CMAC,
+		.is_symmetric = true,
+	},
+};
+
+static const struct test_key_spec *const generate_key_specs[] = {
+	&import_key_specs[0],
+	&import_key_specs[1],
+};
+
+static psa_key_id_t import_plain_key(psa_algorithm_t alg, psa_key_type_t key_type,
+				     psa_key_usage_t usage_flags, const uint8_t *key_data,
+				     size_t key_data_size)
+{
+	psa_key_id_t key_id = PSA_KEY_ID_NULL;
+	psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+	psa_status_t status;
+
+	psa_set_key_usage_flags(&attributes, usage_flags);
+	psa_set_key_algorithm(&attributes, alg);
+	psa_set_key_type(&attributes, key_type);
+
+	status = psa_import_key(&attributes, key_data, key_data_size, &key_id);
+	psa_reset_key_attributes(&attributes);
+
+	zassert_equal(PSA_SUCCESS, status, "psa_import_key err: %d", status);
+	zassert_not_equal(PSA_KEY_ID_NULL, key_id);
+
+	return key_id;
+}
+
+static psa_key_id_t import_plain_verification_key(const struct test_key_spec *spec)
+{
+	return import_plain_key(spec->alg, spec->key_type, PSA_KEY_USAGE_VERIFY_MESSAGE,
+				spec->key_data, spec->key_data_size);
+}
+
+static psa_key_id_t import_plain_public_key(const struct test_key_spec *spec,
+					    const uint8_t *public_key, size_t public_key_size)
+{
+	const psa_key_type_t public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(spec->key_type);
+
+	return import_plain_key(spec->alg, public_key_type, PSA_KEY_USAGE_VERIFY_MESSAGE,
+				public_key, public_key_size);
+}
+
+static void assert_keys_equal(psa_key_id_t signing_key, psa_key_id_t verification_key,
+			      const struct test_key_spec *spec)
+{
+	uint8_t signature[PSA_SIGNATURE_MAX_SIZE] = { 0 };
+	size_t signature_size = 0;
+	psa_status_t status;
+
+	if (spec->is_symmetric) {
+		status = psa_mac_compute(signing_key, spec->alg, test_message, sizeof(test_message),
+					 signature, sizeof(signature), &signature_size);
+		zassert_equal(PSA_SUCCESS, status, "psa_mac_compute err: %d", status);
+
+		status = psa_mac_verify(verification_key, spec->alg, test_message,
+					sizeof(test_message), signature, signature_size);
+		zassert_equal(PSA_SUCCESS, status, "psa_mac_verify err: %d", status);
+		return;
+	}
+
+	status = psa_sign_message(signing_key, spec->alg, test_message, sizeof(test_message),
+				  signature, sizeof(signature), &signature_size);
+	zassert_equal(PSA_SUCCESS, status, "psa_sign_message err: %d", status);
+
+	status = psa_verify_message(verification_key, spec->alg, test_message, sizeof(test_message),
+				    signature, signature_size);
+	zassert_equal(PSA_SUCCESS, status, "psa_verify_message err: %d", status);
+}
 
 static void *setup(void)
 {
@@ -48,64 +200,66 @@ static void after(void *arg)
 ZTEST(crypto_keys, test_sid_crypto_key_invalid_args)
 {
 	int err = -ENOEXEC;
-	uint8_t key_data[TEST_SYMMETRIC_KEY_SIZE] = { 0 };
-	uint8_t ecc_key_data[TEST_ECC_PUBLIC_KEY_SIZE] = { 0 };
+	uint8_t key_data[TEST_AES_KEY_SIZE] = { 0 };
+	uint8_t ecc_key_data[TEST_ED25519_PUBLIC_KEY_SIZE] = { 0 };
 
 	/* Invalid data */
 	psa_key_id_t new_key_id = PSA_KEY_ID_NULL;
-	err = sid_crypto_keys_buffer_get(&new_key_id, NULL, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_buffer_get(&new_key_id, NULL, TEST_AES_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
 	err = sid_crypto_keys_buffer_get(&new_key_id, key_data, 0);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
-	err = sid_crypto_keys_buffer_set(test_key_id, NULL, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_buffer_set(test_key_id, NULL, TEST_AES_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
 	err = sid_crypto_keys_buffer_set(test_key_id, key_data, 0);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
-	err = sid_crypto_keys_new_import(test_key_id, NULL, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_new_import(test_key_id, NULL, TEST_AES_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
 	err = sid_crypto_keys_new_import(test_key_id, key_data, 0);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
-	err = sid_crypto_keys_new_generate(test_key_ecc_id, NULL, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_new_generate(test_key_ecc_id, NULL, TEST_AES_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
 	err = sid_crypto_keys_new_generate(test_key_ecc_id, key_data, 0);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
 	/* Invalid key id */
-	err = sid_crypto_keys_buffer_get(NULL, key_data, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_buffer_get(NULL, key_data, TEST_AES_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
-	err = sid_crypto_keys_buffer_set(PSA_KEY_ID_NULL, key_data, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_buffer_set(PSA_KEY_ID_NULL, key_data, TEST_AES_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
-	err = sid_crypto_keys_new_import(PSA_KEY_ID_NULL, key_data, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_new_import(PSA_KEY_ID_NULL, key_data, TEST_AES_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 
-	err = sid_crypto_keys_new_generate(PSA_KEY_ID_NULL, ecc_key_data, TEST_ECC_PUBLIC_KEY_SIZE);
+	err = sid_crypto_keys_new_generate(PSA_KEY_ID_NULL, ecc_key_data,
+					   TEST_ED25519_PUBLIC_KEY_SIZE);
 	zassert_equal(-EINVAL, err, "err: %d", err);
 }
 
-ZTEST(crypto_keys, test_sid_crypto_key_import)
+ZTEST(crypto_keys, test_sid_crypto_key_buffer)
 {
-	uint8_t test_key_data[TEST_SYMMETRIC_KEY_SIZE] = { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5,
-							   0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB,
-							   0xAC, 0xAD, 0xAE, 0xAF };
+	uint8_t test_key_data[TEST_AES_KEY_SIZE] = {
+		0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7,
+		0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF
+	};
 	psa_key_id_t new_key_id = PSA_KEY_ID_NULL;
 	int err = -ENOEXEC;
 
-	err = sid_crypto_keys_new_import(test_key_id, test_key_data, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_new_import(test_key_id, test_key_data, sizeof(test_key_data));
 	zassert_equal(0, err, "err: %d", err);
 
-	err = sid_crypto_keys_buffer_set(test_key_id, test_key_data, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_buffer_set(test_key_id, test_key_data, sizeof(test_key_data));
 	zassert_equal(0, err, "err: %d", err);
 
-	err = sid_crypto_keys_buffer_get(&new_key_id, test_key_data, TEST_SYMMETRIC_KEY_SIZE);
+	err = sid_crypto_keys_buffer_get(&new_key_id, test_key_data, sizeof(test_key_data));
 	zassert_equal(0, err, "err: %d", err);
 
 	zassert_equal(new_key_id, test_key_id);
@@ -114,16 +268,54 @@ ZTEST(crypto_keys, test_sid_crypto_key_import)
 	zassert_equal(0, err, "err: %d", err);
 }
 
+ZTEST(crypto_keys, test_sid_crypto_key_import)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(import_key_specs); i++) {
+		const struct test_key_spec *spec = &import_key_specs[i];
+		psa_key_id_t verification_key;
+		int err;
+
+		err = sid_crypto_keys_new_import(spec->id, (uint8_t *)spec->key_data,
+						 spec->key_data_size);
+		zassert_equal(0, err, "err: %d id: %d", err, spec->id);
+
+		verification_key = import_plain_verification_key(spec);
+		assert_keys_equal(spec->id, verification_key, spec);
+
+		(void)psa_destroy_key(verification_key);
+
+		err = sid_crypto_keys_delete(spec->id);
+		zassert_equal(0, err, "err: %d id: %d", err, spec->id);
+	}
+}
+
 ZTEST(crypto_keys, test_sid_crypto_key_generate)
 {
-	uint8_t public_key[TEST_ECC_PUBLIC_KEY_SIZE] = { 0 };
-	int err = -ENOEXEC;
+	for (size_t i = 0; i < ARRAY_SIZE(generate_key_specs); i++) {
+		const struct test_key_spec *spec = generate_key_specs[i];
+		uint8_t public_key[PSA_EXPORT_PUBLIC_KEY_MAX_SIZE] = { 0 };
+		size_t public_key_size = spec->public_key_size;
+		size_t public_key_offset = 0;
+		psa_key_id_t verification_key;
+		int err;
 
-	err = sid_crypto_keys_new_generate(test_key_ecc_id, public_key, TEST_ECC_PUBLIC_KEY_SIZE);
-	zassert_equal(0, err, "err: %d", err);
+		if (spec->id == SID_CRYPTO_MFG_SECP_256R1_PRIV_KEY_ID) {
+			// sid_crypto_keys_new_generate exports the public key without the prefix for SECP256R1
+			public_key[public_key_offset++] = 0x04;
+		}
 
-	err = sid_crypto_keys_delete(test_key_ecc_id);
-	zassert_equal(0, err, "err: %d", err);
+		err = sid_crypto_keys_new_generate(spec->id, public_key + public_key_offset,
+						   public_key_size - public_key_offset);
+		zassert_equal(0, err, "err: %d id: %d", err, spec->id);
+
+		verification_key = import_plain_public_key(spec, public_key, public_key_size);
+		assert_keys_equal(spec->id, verification_key, spec);
+
+		(void)psa_destroy_key(verification_key);
+
+		err = sid_crypto_keys_delete(spec->id);
+		zassert_equal(0, err, "err: %d id: %d", err, spec->id);
+	}
 }
 
 ZTEST_SUITE(crypto_keys, NULL, setup, before, after, teardown);

--- a/tests/integration/crypto_keys/testcase.yaml
+++ b/tests/integration/crypto_keys/testcase.yaml
@@ -10,3 +10,17 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+
+  sidewalk.test.integration.crypto_keys.no_kmu:
+    sysbuild: true
+    tags: Sidewalk
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_configs:
+      - CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE_KMU=n


### PR DESCRIPTION
## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: KRKNWK-22043

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
