### PR TITLE
manifest: add cmock to nrf import allowlist

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,6 +27,7 @@ manifest:
           - trusted-firmware-m
           - zcbor
           - zephyr
+          - cmock
           # nRF53 only (multicore):
           - libmetal
           - open-amp


### PR DESCRIPTION
Unity-based validation tests need cmock sources.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
