### PR TITLE
ci: sync NCS toolchain in GitHub Actions and Docker

### DIFF
--- a/.github/actions/setup-ncs-toolchain/action.yml
+++ b/.github/actions/setup-ncs-toolchain/action.yml
@@ -1,0 +1,35 @@
+name: Setup NCS toolchain
+description: >
+  Make the NCS toolchain matching west.yml active for bash steps via BASH_ENV.
+  Call once after checkout (uses the pre-baked toolchain so west is available)
+  and once after 'west update' (installs the toolchain the manifest requires).
+
+runs:
+  using: composite
+  steps:
+    - name: Setup NCS toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # sdk-manager is installed in the image; BASH_ENV would hide it.
+        export NRFUTIL_HOME=/usr/local/share/nrfutil
+        NCS_INSTALL_DIR=/root/ncs
+
+        nrfutil install sdk-manager
+
+        if [ -x nrf/scripts/print_toolchain_checksum.sh ]; then
+          BUNDLE_ID=$(nrf/scripts/print_toolchain_checksum.sh)
+          if [ ! -d "${NCS_INSTALL_DIR}/toolchains/${BUNDLE_ID}" ]; then
+            nrfutil sdk-manager toolchain install \
+              --toolchain-bundle-id "${BUNDLE_ID}" --install-dir "${NCS_INSTALL_DIR}"
+          fi
+        else
+          BUNDLE_ID=$(basename "$(find "${NCS_INSTALL_DIR}/toolchains" -mindepth 1 -maxdepth 1 -type d | head -1)")
+        fi
+        echo "Using toolchain bundle ${BUNDLE_ID}"
+
+        nrfutil sdk-manager toolchain env \
+          --toolchain-bundle-id "${BUNDLE_ID}" --install-dir "${NCS_INSTALL_DIR}" \
+          --as-script sh > /opt/toolchain-env.sh
+        echo "BASH_ENV=/opt/toolchain-env.sh" >> "${GITHUB_ENV}"

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL org.opencontainers.image.source="https://github.com/nrfconnect/sdk-sidewalk"
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -7,21 +7,23 @@ ARG tools_version_minor=24
 ARG tools_version_patch=2
 
 ARG NRF_VERSION=main
+ARG TOOLCHAIN_BUNDLE_ID
+ARG NCS_INSTALL_DIR=/root/ncs
 
 ARG command_line_tools_name=nrf-command-line-tools_${tools_version_major}.${tools_version_minor}.${tools_version_patch}_amd64.deb
 ARG command_line_tools_url=https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-${tools_version_major}-x-x/${tools_version_major}-${tools_version_minor}-${tools_version_patch}/${command_line_tools_name}
 
 RUN apt-get update; apt-get install --no-install-recommends -y wget curl libusb-1.0-0 \
-  clangd ssh nano bash-completion gpg ruby lcov screen libffi7 libffi-dev libfftw3-dev python3-venv \
-  git-lfs golang-go clang-format python3-pip python3-autopep8 gitlint libmagic1 git gcc g++ gcc-multilib lbzip2 jq sudo zip make gdb vim wget unzip
+  clangd ssh nano bash-completion gpg ruby lcov screen libffi-dev libfftw3-dev python3-venv \
+  git-lfs golang-go clang-format python3-pip python3-autopep8 gitlint libmagic1 git gcc g++ gcc-multilib lbzip2 jq sudo zip make gdb vim wget unzip \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV NRFUTIL_HOME=/usr/local/share/nrfutil
 RUN <<EOT
     mkdir -p /usr/local/share/nrfutil
-    wget -q https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil
-    mv nrfutil /usr/local/bin
+    wget -q https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil -O /usr/local/bin/nrfutil
     chmod +x /usr/local/bin/nrfutil
-    nrfutil install toolchain-manager
+    nrfutil install sdk-manager
     nrfutil install device
     nrfutil install completion
 EOT
@@ -31,7 +33,7 @@ RUN dpkg -i ${command_line_tools_name}
 
 RUN <<EOT
     echo '#!/bin/bash\necho not running udevadm "$@"' > /usr/bin/udevadm
-    chmod +x /usr/bin/udevadm 
+    chmod +x /usr/bin/udevadm
     JLink_to_install=`ls /opt/nrf-command-line-tools/share | grep JLink_Linux`
     apt install -y /opt/nrf-command-line-tools/share/$JLink_to_install --fix-broken
 EOT
@@ -44,17 +46,20 @@ RUN <<EOT
 EOT
 
 RUN <<EOT
-    nrfutil toolchain-manager install --toolchain-bundle-id $(/workdir/nrf/scripts/print_toolchain_checksum.sh)
-    nrfutil toolchain-manager list
+    BUNDLE_ID="${TOOLCHAIN_BUNDLE_ID}"
+    if [ -z "$BUNDLE_ID" ]; then
+      BUNDLE_ID=$(/workdir/nrf/scripts/print_toolchain_checksum.sh)
+    fi
+    nrfutil sdk-manager toolchain install --toolchain-bundle-id "$BUNDLE_ID" --install-dir ${NCS_INSTALL_DIR}
+    nrfutil sdk-manager toolchain env --toolchain-bundle-id "$BUNDLE_ID" --install-dir ${NCS_INSTALL_DIR} --as-script sh > /opt/toolchain-env.sh
 EOT
 
+ENV BASH_ENV=/opt/toolchain-env.sh
 WORKDIR /workdir
-SHELL ["nrfutil","toolchain-manager","launch","/bin/bash","--","-c"]
+SHELL ["/bin/bash", "-c"]
 RUN <<EOT
-    west init -l nrf 
+    west init -l nrf
     west update
     python3 -m pip install devicetree
-    python3 -m pip install -r /workdir/nrf/scripts/requirements.txt -r /workdir/zephyr/scripts/requirements.txt 
+    python3 -m pip install -r /workdir/nrf/scripts/requirements.txt -r /workdir/zephyr/scripts/requirements.txt
 EOT
-
-# add your commands below

--- a/.github/workflows/on_docker_change.yml
+++ b/.github/workflows/on_docker_change.yml
@@ -3,13 +3,19 @@ name: Build and publish Docker image
 on:
 
   workflow_dispatch:
+    inputs:
+      nrf_version:
+        description: 'NCS revision (default: from west.yml)'
+        required: false
+        type: string
 
   push:
     branches:
       - main
     paths:
       - '.github/docker/**'
-      - '.github/workflow/on_docker_change.yml'
+      - '.github/workflows/on_docker_change.yml'
+      - 'west.yml'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
@@ -30,12 +36,34 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get revision of nrf to use
+        id: revision
+        run: |
+          REF_NAME="${{ github.event.inputs.nrf_version }}"
+          if [ -z "$REF_NAME" ]; then
+            REF_NAME=$(yq '.manifest.projects | map(select(.name == "nrf"))[0].revision' west.yml)
+          fi
+          echo "REF_NAME=$REF_NAME" >> $GITHUB_OUTPUT
+          echo "Ref name: $REF_NAME"
+
+      - name: Resolve toolchain bundle ID
+        id: toolchain
+        run: |
+          REF="${{ steps.revision.outputs.REF_NAME }}"
+          git init /tmp/nrf
+          git -C /tmp/nrf remote add origin https://github.com/nrfconnect/sdk-nrf
+          git -C /tmp/nrf fetch --depth 1 origin "${REF}"
+          git -C /tmp/nrf checkout FETCH_HEAD
+          echo "bundle_id=$(/tmp/nrf/scripts/print_toolchain_checksum.sh)" >> $GITHUB_OUTPUT
+          echo "Toolchain bundle: $(/tmp/nrf/scripts/print_toolchain_checksum.sh)"
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -50,20 +78,17 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
 
-      - name: Get revision of nrf to use
-        id: revision
-        run: |
-          REF_NAME=$(yq '.manifest.projects | map(select(.name == "nrf"))[0].revision' west.yml)
-          echo "REF_NAME=$REF_NAME" >> $GITHUB_OUTPUT
-          echo "Ref name: $REF_NAME"
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: .github/docker/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.toolchain.outputs.bundle_id }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args:
+          build-args: |
             NRF_VERSION=${{ steps.revision.outputs.REF_NAME }}
+            TOOLCHAIN_BUNDLE_ID=${{ steps.toolchain.outputs.bundle_id }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ jobs:
       options: --cpus 2
     defaults:
       run:
-        shell: nrfutil toolchain-manager launch --install-dir /root/ncs bash -- {0}
+        shell: bash -- {0}
 
     steps:
       - name: Checkout
@@ -26,11 +26,17 @@ jobs:
           fetch-depth: 0
           path: sidewalk
 
+      - name: Setup NCS toolchain (pre-baked)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
+
       - name: update NRF
         run: |
           rm -rf .west;
           west init -l sidewalk --mf west.yml &&
           west update -n -o=--depth=1 --path-cache /workdir/
+
+      - name: Setup NCS toolchain (from manifest)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/samples_build.yml
+++ b/.github/workflows/samples_build.yml
@@ -24,7 +24,7 @@ jobs:
       subset_config: ${{ steps.subsets.outputs.config }}
     defaults:
       run:
-        shell: nrfutil toolchain-manager launch --install-dir /root/ncs bash -- {0}
+        shell: bash -- {0}
 
     steps:
       - name: Checkout
@@ -33,11 +33,17 @@ jobs:
           fetch-depth: 0
           path: sidewalk
 
+      - name: Setup NCS toolchain (pre-baked)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
+
       - name: update NRF
         run: |
           rm -rf .west;
           west init -l sidewalk --mf west.yml &&
           west update -n -o=--depth=1 --path-cache /workdir/
+
+      - name: Setup NCS toolchain (from manifest)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
 
       - name: subsets configuration
         id: subsets

--- a/.github/workflows/samples_build_target.yml
+++ b/.github/workflows/samples_build_target.yml
@@ -26,7 +26,7 @@ jobs:
       options: --cpus 2
     defaults:
       run:
-        shell: nrfutil toolchain-manager launch --install-dir /root/ncs bash -- {0}
+        shell: bash -- {0}
 
     steps:
       - name: get_max_subset
@@ -43,11 +43,17 @@ jobs:
           fetch-depth: 0
           path: sidewalk
 
+      - name: Setup NCS toolchain (pre-baked)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
+
       - name: update NRF
         run: |
           rm -rf .west;
           west init -l sidewalk --mf west.yml &&
           west update -n -o=--depth=1 --path-cache /workdir/
+
+      - name: Setup NCS toolchain (from manifest)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/validate_code_style.yml
+++ b/.github/workflows/validate_code_style.yml
@@ -40,7 +40,7 @@ jobs:
       options: --cpus 2
     defaults:
       run:
-        shell: nrfutil toolchain-manager launch --install-dir /root/ncs bash -- {0}
+        shell: bash -- {0}
 
     steps:
       - name: Checkout
@@ -58,11 +58,17 @@ jobs:
           path: sidewalk
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup NCS toolchain (pre-baked)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
+
       - name: update NRF
         run: |
           rm -rf .west;
           west init -l sidewalk --mf west.yml &&
           west update -n -o=--depth=1 --path-cache /workdir/
+
+      - name: Setup NCS toolchain (from manifest)
+        uses: ./sidewalk/.github/actions/setup-ncs-toolchain
 
       - name: Install compliance requirements
         run: |


### PR DESCRIPTION
## Summary

CI runs in a Docker image that ships with a fixed NCS toolchain. When west.yml bumps NCS (e.g. v3.3.0 → v3.4.0), jobs still pull the old :main image but fetch new source code - builds fail because the toolchain no longer matches.

**On PR:** a setup-ncs-toolchain step installs the toolchain required by the PR’s west.yml at runtime if the image is stale. PR CI stays green without rebuilding Docker first.

**After merge to main:** the Docker rebuild workflow runs when west.yml (or Docker files) change, so :main is updated with the matching toolchain for faster CI on later PRs.

**Older NCS on a PR:** if main already has NCS 3.4.0 and a PR still uses 3.3.0, Docker is not rebuilt on that PR. CI still uses :main and installs the 3.3.0 toolchain at runtime if needed. Docker rebuilds only when such a change is merged to main. The registry may keep multiple toolchain tags (e.g. :911f4c5c26, :fbf7391cab); CI always pulls :main.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
