### PR TITLE
samples: sid_end_device: exclude nRF52 from nrf_sidewalk_eb variants

### DIFF
--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -47,6 +47,8 @@ tests:
       - lr1110
 
   sample.sidewalk.hello.nrf_sidewalk_eb:
+    platform_exclude:
+      - nrf52840dk/nrf52840
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -87,6 +89,8 @@ tests:
       - lr1110
 
   sample.sidewalk.hello.release.nrf_sidewalk_eb:
+    platform_exclude:
+      - nrf52840dk/nrf52840
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -272,6 +276,8 @@ tests:
       - sx1262
 
   sample.sidewalk.helloPower.fsk.release.nrf_sidewalk_eb:
+    platform_exclude:
+      - nrf52840dk/nrf52840
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -287,6 +293,8 @@ tests:
       - lr1110
 
   sample.sidewalk.helloPower.lora.release.nrf_sidewalk_eb:
+    platform_exclude:
+      - nrf52840dk/nrf52840
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp


### PR DESCRIPTION
Fix build issues in CI by excluding nRF52 when building the variants that enable nRF Sidewalk EB.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
