### PR TITLE
sal: sid_pal: add DEV_ID_REG for nRF54LM20B

### DIFF
--- a/subsys/sal/sid_pal/src/sid_mfg_storage.c
+++ b/subsys/sal/sid_pal/src/sid_mfg_storage.c
@@ -42,8 +42,7 @@ static int sid_mfg_storage_secure_read(uint16_t *p_value, uint8_t *buffer, uint1
 #ifndef DEV_ID_REG
 #if defined(NRF52840_XXAA) || defined(NRF52833_XXAA) || defined(NRF52832_XXAA)
 #define DEV_ID_REG (uint32_t)(NRF_FICR->DEVICEID[0])
-#elif defined(NRF54L15_XXAA) || defined(NRF54L10_XXAA) || defined(NRF54LV10A_XXAA) ||                \
-	defined(NRF54LM20A_XXAA)
+#elif defined(CONFIG_SOC_SERIES_NRF54L)
 #define DEV_ID_REG (uint32_t)(NRF_FICR->INFO.DEVICEID[0])
 #else
 #error "Unknown Device ID register."

--- a/subsys/sal/sid_pal/src/sid_mfg_storage_deprecated.c
+++ b/subsys/sal/sid_pal/src/sid_mfg_storage_deprecated.c
@@ -38,8 +38,7 @@ LOG_MODULE_REGISTER(sid_mfg, CONFIG_SIDEWALK_LOG_LEVEL);
 #ifndef DEV_ID_REG
 #if defined(NRF52840_XXAA) || defined(NRF52833_XXAA) || defined(NRF52832_XXAA)
 #define DEV_ID_REG (uint32_t)(NRF_FICR->DEVICEID[0])
-#elif defined(NRF54L15_XXAA) || defined(NRF54L10_XXAA) || defined(NRF54LV10A_XXAA) ||                \
-	defined(NRF54LM20A_XXAA)
+#elif defined(CONFIG_SOC_SERIES_NRF54L)
 #define DEV_ID_REG (uint32_t)(NRF_FICR->INFO.DEVICEID[0])
 #else
 #error "Unknown Device ID register."


### PR DESCRIPTION
Builds for nrf54lm20dk/nrf54lm20b/cpuapp hit the "Unknown Device ID register." #error because the guard listed only NRF54LM20A_XXAA. nRF54LM20B has an identical FICR layout, with DEVICEID[2] at offset 0x04 of INFO, so it uses the same register.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
