### PR TITLE
sal: ble: disconnect BLE link explicitly on deinit

### DIFF
--- a/subsys/sal/sid_pal/src/sid_ble_adapter.c
+++ b/subsys/sal/sid_pal/src/sid_ble_adapter.c
@@ -572,6 +572,7 @@ static sid_error_t ble_adapter_disconnect(void)
 static sid_error_t ble_adapter_deinit(void)
 {
 	LOG_DBG("Sidewalk -> BLE");
+	sid_ble_conn_disconnect();
 	sid_ble_conn_deinit();
 	sid_ble_advert_deinit();
 	bt_id_delete(BT_ID_SIDEWALK);


### PR DESCRIPTION
This commit triggers explicit BLE disconnection on deinit.

The code later on calls `sid_ble_bt_disable`, however, it does not always call `bt_disable` (it depends on other BLE modules).

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [x] There is no commented code.
- [x] There are no TODO/FIXME comments without associated issue ticket.
- [x] Commits are properly organized.
- [x] Change has been tested.
- [x] Tests were updated (if applicable).
