### PR TITLE
nrf70_location: add dependency on Zephyr generated headers

### DIFF
--- a/subsys/nrf70_location/CMakeLists.txt
+++ b/subsys/nrf70_location/CMakeLists.txt
@@ -13,3 +13,5 @@ target_link_libraries(sid_pal_wifi_nrf70_impl PUBLIC
 	sid_pal_wifi_ifc
 	zephyr_interface
 )
+
+add_dependencies(sid_pal_wifi_nrf70_impl zephyr_generated_headers)


### PR DESCRIPTION
nrf70_location is an external library, whose build might be scheduled prior to generating Zephyr headers.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
