### PR TITLE
samples: sid_end_device: remote no_secure build from sample.yaml

### DIFF
--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -257,17 +257,6 @@ tests:
       - cli
       - BLE
 
-  sample.sidewalk.dut.no_secure:
-    extra_args:
-      - OVERLAY_CONFIG="overlay-dut.conf"
-      - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
-    extra_configs:
-      - CONFIG_SIDEWALK_CRYPTO_PSA_KEY_STORAGE=n
-      - CONFIG_SIDEWALK_APPLICATION_NAME="dut.no_secure"
-    tags:
-      - cli
-      - no_secure
-
   sample.sidewalk.helloPower.ble.release:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp


### PR DESCRIPTION
Secure storage is now the only supported option so remove the non-secure storage variant from twister testing.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: KRKNWK-22043

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
