### PR TITLE
workflows: fix PR config and size comparison

### DIFF
--- a/.github/workflows/compare_config.yml
+++ b/.github/workflows/compare_config.yml
@@ -29,6 +29,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           run_id: ${{inputs.current_run_id}}
+          name: sample-artifacts-meta
           path: current
 
       - name: Get artifacts from base
@@ -37,6 +38,10 @@ jobs:
         with:
           commit: ${{inputs.base_commit_sha}}
           workflow: on-commit.yml
+          workflow_conclusion: success
+          name: sample-artifacts-meta
+          search_artifacts: true
+          check_artifacts: true
           path: old
 
       - name: Get artifacts from base
@@ -44,34 +49,43 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: on-commit.yml
+          workflow_conclusion: success
+          name: sample-artifacts-meta
+          search_artifacts: true
+          check_artifacts: true
           path: old
 
       - name: Generate .config diff
         shell: bash {0}
         id: config_diff
         run: |
-          cd current
-          configs=$(find . -name .config)
-          cd ..
+          configs=$(find current -name .config)
           echo "\`\`\`" >> config_diff.md
           for cfg in ${configs}
           do
-            echo "compare ${cfg}"
+            rel_cfg="${cfg#current/}"
+            old_cfg="old/${rel_cfg}"
+            if [ ! -f "${old_cfg}" ]; then
+              echo "Skipping ${rel_cfg} - no baseline .config"
+              continue
+            fi
 
-            grep -v "CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION" old/${cfg} > tmp_old.1
+            echo "compare ${rel_cfg}"
+
+            grep -v "CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION" "${old_cfg}" > tmp_old.1
             grep -v "#"  tmp_old.1 > tmp_old.2
             sort tmp_old.2 > tmp_old.3
-            tr -s '\n' < tmp_old.3 > old/${cfg}
+            tr -s '\n' < tmp_old.3 > tmp_old.4
 
-            grep -v "CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION" current/${cfg} > tmp_current.1
+            grep -v "CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION" "${cfg}" > tmp_current.1
             grep -v "#"  tmp_current.1 > tmp_current.2
             sort tmp_current.2 > tmp_current.3
-            tr -s '\n' < tmp_current.3 > current/${cfg}
+            tr -s '\n' < tmp_current.3 > tmp_current.4
 
             rm -rf tmp_*
 
-            printf "\n%s\n%-62s| %s\n" "${cfg}" "old" "new" > cfg_diff.md
-            diff --text --report-identical-files --suppress-common-lines --side-by-side --label old --label new old/${cfg} current/${cfg} >> cfg_diff.md
+            printf "\n%s\n%-62s| %s\n" "${rel_cfg}" "old" "new" > cfg_diff.md
+            diff --text --report-identical-files --suppress-common-lines --side-by-side --label old --label new tmp_old.4 tmp_current.4 >> cfg_diff.md
             if [ $? -eq 1 ]; then cat cfg_diff.md >> config_diff.md; fi
           done
           echo "\`\`\`" >> config_diff.md

--- a/.github/workflows/on-pr_publish_comment.yml
+++ b/.github/workflows/on-pr_publish_comment.yml
@@ -21,6 +21,7 @@ jobs:
       pull-requests: write
       contents: read
       checks: write
+      actions: read
 
     steps:
       - name: Checkout
@@ -30,13 +31,25 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           run_id: ${{github.event.workflow_run.id}}
+          name: sample-artifacts-meta
           path: current
+
+      - name: Get PR number
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          run_id: ${{github.event.workflow_run.id}}
+          name: PR_number
+          path: current/PR_number
 
       - name: Get artifacts from PR base
         uses: dawidd6/action-download-artifact@v6
         with:
           commit: ${{github.event.workflow_run.event.pull_request.base.sha}}
           workflow: on-commit.yml
+          workflow_conclusion: success
+          name: sample-artifacts-meta
+          search_artifacts: true
+          check_artifacts: true
           path: old
 
       - name: Unpack PR number
@@ -48,11 +61,11 @@ jobs:
       - name: Generage memory diff
         run: |
           shopt -s extglob
-          pr_reports=$(ls current/sample-artifacts-meta/subsets/*/twister.json)
+          pr_reports=$(ls current/subsets/*/twister.json)
           python3 scripts/ci/combine_twister_reports.py $pr_reports new.json
           cat new.json
 
-          base_reports=$(ls old/sample-artifacts-meta/subsets/*/twister.json)
+          base_reports=$(ls old/subsets/*/twister.json)
           python3 scripts/ci/combine_twister_reports.py $base_reports old.json
           cat old.json
 


### PR DESCRIPTION
The workflow should specify the artifact name to ensure that the build metadata and not doc artifact is downloaded before the comparison is attempted.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
