### PR TITLE
samples: sid_end_device: exclude nRF54L15 DK from Sidewalk EB hello

### DIFF
--- a/doc/samples/variants/hello.rst
+++ b/doc/samples/variants/hello.rst
@@ -21,6 +21,12 @@ The sample variant supports the following Kconfig options:
 User Interface
 **************
 
+.. note::
+   This sample variant is not supported on the `nRF54L15 DK`_ with the :ref:`nRF Sidewalk EB <nrf_sidewalk_eb>` shield.
+   The shield uses the pins of **Button 0**, **Button 1**, **Button 2**, **LED 1**, and **LED 3**, which makes the user interface described in this section unavailable.
+   To run this sample variant over LoRa or FSK, use either the shield with the `nRF54LM20 DK`_, or a Semtech shield with the `nRF54L15 DK`_.
+   For the pin assignment and usage requirements of the shield, see :ref:`nrf_sidewalk_eb`.
+
 .. tabs::
 
    .. group-tab:: nRF54 DKs

--- a/samples/sid_end_device/sample.yaml
+++ b/samples/sid_end_device/sample.yaml
@@ -10,13 +10,13 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
-  integration_platforms:
-    - nrf54l15dk/nrf54l15/cpuapp
   tags:
     - Sidewalk
 
 tests:
   sample.sidewalk.hello.sx1262:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-hello.conf"
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -29,6 +29,8 @@ tests:
       - sx1262
 
   sample.sidewalk.hello.lr1110:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     build_only: false
     extra_args:
       - OVERLAY_CONFIG="overlay-hello.conf"
@@ -47,8 +49,13 @@ tests:
       - lr1110
 
   sample.sidewalk.hello.nrf_sidewalk_eb:
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_exclude:
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -64,6 +71,8 @@ tests:
       - lr1110
 
   sample.sidewalk.hello.release.sx1262:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - FILE_SUFFIX=release
       - OVERLAY_CONFIG="overlay-hello.conf"
@@ -76,6 +85,8 @@ tests:
       - sx1262
 
   sample.sidewalk.hello.release.lr1110:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - FILE_SUFFIX=release
       - OVERLAY_CONFIG="overlay-hello.conf"
@@ -89,8 +100,13 @@ tests:
       - lr1110
 
   sample.sidewalk.hello.release.nrf_sidewalk_eb:
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_exclude:
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -106,6 +122,8 @@ tests:
       - lr1110
 
   sample.sidewalk.hello.ble_only:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     build_only: false
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
@@ -123,6 +141,8 @@ tests:
       - BLE
 
   sample.sidewalk.hello.ble_only.release:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
@@ -135,6 +155,8 @@ tests:
       - BLE
 
   sample.sidewalk.demo.sx1262:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-demo.conf"
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -146,6 +168,8 @@ tests:
       - sx1262
 
   sample.sidewalk.demo.lr1110:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-demo.conf"
       - SHIELD="simple_arduino_adapter;semtech_lr1110mb1xxs"
@@ -157,6 +181,8 @@ tests:
       - lr1110
 
   sample.sidewalk.demo.ble_only:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args: OVERLAY_CONFIG="overlay-demo.conf"
     extra_configs:
       - CONFIG_SIDEWALK_APPLICATION_NAME="demo.ble_only"
@@ -165,6 +191,8 @@ tests:
       - BLE
 
   sample.sidewalk.dut.sx1262:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - OVERLAY_CONFIG="overlay-dut.conf"
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -175,6 +203,8 @@ tests:
       - sx1262
 
   sample.sidewalk.dut.lr1110:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     build_only: false
     platform_exclude:
       - nrf54l15dk/nrf54l15/cpuapp/ns
@@ -193,6 +223,8 @@ tests:
       - lr1110
 
   sample.sidewalk.dut.ble_only.nrf7002eb2:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_exclude:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l10/cpuapp
@@ -207,6 +239,8 @@ tests:
       - nrf70
 
   sample.sidewalk.dut.nrf7002eb2.sx1262:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_exclude:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l10/cpuapp
@@ -223,6 +257,8 @@ tests:
       - sx1262
 
   sample.sidewalk.dut.nrf_sidewalk_eb:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_exclude:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp/ns
@@ -240,6 +276,8 @@ tests:
       - lr1110
 
   sample.sidewalk.dut.ble_only:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     build_only: false
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
@@ -258,6 +296,8 @@ tests:
       - BLE
 
   sample.sidewalk.helloPower.ble.release:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
@@ -271,6 +311,8 @@ tests:
       - helloPower
 
   sample.sidewalk.helloPower.fsk.release.sx1262:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - FILE_SUFFIX=release
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -283,6 +325,8 @@ tests:
       - sx1262
 
   sample.sidewalk.helloPower.lora.release.sx1262:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - FILE_SUFFIX=release
       - SHIELD="simple_arduino_adapter;semtech_sx1262mb2cas"
@@ -295,6 +339,8 @@ tests:
       - sx1262
 
   sample.sidewalk.helloPower.fsk.release.nrf_sidewalk_eb:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_exclude:
       - nrf52840dk/nrf52840
     platform_allow:
@@ -312,6 +358,8 @@ tests:
       - lr1110
 
   sample.sidewalk.helloPower.lora.release.nrf_sidewalk_eb:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_exclude:
       - nrf52840dk/nrf52840
     platform_allow:
@@ -329,6 +377,8 @@ tests:
       - lr1110
 
   sample.sidewalk.helloPower.ble_only.release:
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp


### PR DESCRIPTION
The nRF Sidewalk EB shield occupies the pins used by Button 0, Button 1, Button 2, LED 1, and LED 3 on the nRF54L15 DK, which makes the hello variant user interface unavailable. Exclude the nRF54L15 and nRF54L10 targets from the shield test cases and document the limitation.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
