### PR TITLE
doc: add nRF70 Series Wi-Fi location documentation

### DIFF
--- a/doc/links.rst
+++ b/doc/links.rst
@@ -14,6 +14,7 @@
 .. _nRF54LM20 DK: https://docs.nordicsemi.com/bundle/ncs-3.4.0/page/zephyr/boards/nordic/nrf54lm20dk/doc/index.html
 .. _nrf54lv10dk: https://docs.nordicsemi.com/bundle/ncs-3.4.0/page/zephyr/boards/nordic/nrf54lv10dk/doc/index.html
 .. _nrf54lm20dk: https://docs.nordicsemi.com/bundle/ncs-3.4.0/page/zephyr/boards/nordic/nrf54lm20dk/doc/index.html
+.. _nRF7002 EB II: https://docs.nordicsemi.com/bundle/ncs-3.4.0/page/zephyr/boards/shields/nrf7002eb2/doc/index.html
 .. _Building and programming an application: https://docs.nordicsemi.com/bundle/ncs-3.4.0/page/nrf/config_and_build/programming.html
 .. _Testing and debugging an application: https://docs.nordicsemi.com/bundle/ncs-3.4.0/page/nrf/test_and_optimize.html
 .. _Bootloader and DFU solutions for NCS: https://docs.nordicsemi.com/bundle/ncs-3.4.0/page/nrf/config_and_build/bootloaders/index.html
@@ -48,6 +49,9 @@
 .. _nRF54LV10A Product Page: https://www.nordicsemi.com/Products/nRF54LV10A
 .. _nRF54LM20A Product Page: https://www.nordicsemi.com/Products/nRF54LM20A
 .. _nRF54LM20B Product Page: https://www.nordicsemi.com/Products/nRF54LM20B
+.. _nRF7000 Product Page: https://www.nordicsemi.com/Products/nRF7000
+.. _nRF7001 Product Page: https://www.nordicsemi.com/Products/nRF7001
+.. _nRF7002 Product Page: https://www.nordicsemi.com/Products/nRF7002
 
 .. github.com
 

--- a/doc/location_services.rst
+++ b/doc/location_services.rst
@@ -32,7 +32,10 @@ These methods are supported on two available link types:
 .. note::
    FSK with Wi-Fi and GNSS scanning enabled is not currently supported.
 
-Wi-Fi and GNSS scanning use the Semtech LoRa Basics Modem middleware to manage and perform scans on the device.
+GNSS scanning uses the Semtech LoRa Basics Modem middleware to manage and perform scans on the device, and requires the LR1110 radio.
+Wi-Fi scanning can use either the LR1110 with the same middleware, or an nRF70 Series Wi-Fi companion IC.
+The two implementations are mutually exclusive, so only one of them can be enabled in a build.
+For more information about the nRF70 Series-based Wi-Fi location, see :ref:`location_services_nrf70`.
 
 .. list-table:: Hardware and Library Requirements for Location Methods
    :header-rows: 1
@@ -43,9 +46,12 @@ Wi-Fi and GNSS scanning use the Semtech LoRa Basics Modem middleware to manage a
    * - BLE Location
      - nRF chip
      - BLE only, or LoRa/FSK
-   * - Wi-Fi Location
+   * - Wi-Fi Location (LR1110)
      - nRF chip and LR1110 radio
      - LoRa and FSK
+   * - Wi-Fi Location (nRF70 Series)
+     - nRF chip and nRF70 Series Wi-Fi companion IC
+     - BLE only, or LoRa/FSK
    * - GNSS Location
      - nRF chip and LR1110 radio
      - LoRa and FSK
@@ -53,6 +59,7 @@ Wi-Fi and GNSS scanning use the Semtech LoRa Basics Modem middleware to manage a
 .. note::
    Semtech SX1262 radio does not support Wi-Fi and GNSS scans.
    However, you can still use Bluetooth LE location features while using the SX1262 for LoRa and FSK communication.
+   To add Wi-Fi-based location, use an nRF70 Series Wi-Fi companion IC.
 
 Location Levels
 ===============
@@ -100,6 +107,24 @@ At this level, the device uses satellite data for location.
 * Description - The device collects and sends GNSS (satellite) data.
   At least four satellites must be detected for a valid scan.
 
+.. _location_services_nrf70:
+
+Wi-Fi location using the nRF70 Series
+*************************************
+
+As an alternative to the LR1110-based Wi-Fi scan, Wi-Fi location can be resolved using an nRF70 Series Wi-Fi companion IC.
+The nRF70 Series does not provide GNSS, so the GNSS location level remains unavailable in such a build.
+
+* Support is enabled automatically through the ``CONFIG_SIDEWALK_NRF7X_LOCATION`` Kconfig option when building with an nRF7002 EB II shield.
+  See :ref:`sid_end_device_wifi_location_hw` for the supported shield variants.
+* The nRF70 Series-based location is mutually exclusive with the LR1110-based location.
+  It is unavailable when the LR1110 is selected as the sub-GHz radio, which is also the case for the :ref:`nRF Sidewalk EB <nrf_sidewalk_eb>`.
+* The companion IC runs in the scan-only mode of the nRF70 driver (the ``CONFIG_NRF70_SCAN_ONLY`` Kconfig option, enabled by default for this feature), which provides Wi-Fi scanning without Wi-Fi connectivity.
+* The Wi-Fi scan type can be selected with the ``SIDEWALK_NRF7X_LOCATION_SCAN_TYPE`` Kconfig choice:
+
+  * ``CONFIG_SIDEWALK_NRF7X_LOCATION_SCAN_ACTIVE`` (default) - Resolves access points faster, at the cost of higher power consumption.
+  * ``CONFIG_SIDEWALK_NRF7X_LOCATION_SCAN_PASSIVE`` - Lower power consumption, but slower access point discovery.
+
 Testing
 *******
 
@@ -114,8 +139,9 @@ Location service is supported in Sidewalk libraries in the following range:
 * Sidewalk Sub-GHz library (LoRa and FSK) supports all location methods.
   However to build with radio and pal componets for WiFi and GNSS scanning, ``CONFIG_SIDEWALK_SUBGHZ_RADIO_LR1110`` must be enabled.
   This config is enabled automatically when sample is build with ``semtech_lr11xxmb1xxs`` shield.
+  Alternatively, the Wi-Fi scanning alone can be provided by an nRF70 Series companion IC, as described in :ref:`location_services_nrf70`.
 
-* Sidewalk Bluetooth LE only library supports only network location method over Bluetooth LE.
+* Sidewalk Bluetooth LE only library supports the network location method over Bluetooth LE, and the Wi-Fi location method when an nRF70 Series companion IC is used.
 
 Writing custom application
 **************************

--- a/doc/location_services.rst
+++ b/doc/location_services.rst
@@ -35,7 +35,7 @@ These methods are supported on two available link types:
 GNSS scanning uses the Semtech LoRa Basics Modem middleware to manage and perform scans on the device, and requires the LR1110 radio.
 Wi-Fi scanning can use either the LR1110 with the same middleware, or an nRF70 Series Wi-Fi companion IC.
 The two implementations are mutually exclusive, so only one of them can be enabled in a build.
-For more information about the nRF70 Series-based Wi-Fi location, see :ref:`location_services_nrf70`.
+For more information about the nRF70 Series-based Wi-Fi location, see :ref:`location_services_wifi_nrf70`.
 
 .. list-table:: Hardware and Library Requirements for Location Methods
    :header-rows: 1
@@ -107,23 +107,29 @@ At this level, the device uses satellite data for location.
 * Description - The device collects and sends GNSS (satellite) data.
   At least four satellites must be detected for a valid scan.
 
-.. _location_services_nrf70:
+.. _location_services_wifi_nrf70:
 
-Wi-Fi location using the nRF70 Series
-*************************************
+Wi-Fi scanning with the nRF70 Series
+************************************
 
-As an alternative to the LR1110-based Wi-Fi scan, Wi-Fi location can be resolved using an nRF70 Series Wi-Fi companion IC.
-The nRF70 Series does not provide GNSS, so the GNSS location level remains unavailable in such a build.
+As an alternative to the LR1110 radio, you can use an nRF70 Series Wi-Fi companion IC to perform the Wi-Fi scans from which the location service resolves the device position.
+Support is enabled automatically when you build with an nRF7002 EB II shield, which selects the ``CONFIG_SIDEWALK_NRF7X_LOCATION`` Kconfig option.
+For the list of supported shield variants, see :ref:`sid_end_device_wifi_location_hw`.
 
-* Support is enabled automatically through the ``CONFIG_SIDEWALK_NRF7X_LOCATION`` Kconfig option when building with an nRF7002 EB II shield.
-  See :ref:`sid_end_device_wifi_location_hw` for the supported shield variants.
-* The nRF70 Series-based location is mutually exclusive with the LR1110-based location.
-  It is unavailable when the LR1110 is selected as the sub-GHz radio, which is also the case for the :ref:`nRF Sidewalk EB <nrf_sidewalk_eb>`.
-* The companion IC runs in the scan-only mode of the nRF70 driver (the ``CONFIG_NRF70_SCAN_ONLY`` Kconfig option, enabled by default for this feature), which provides Wi-Fi scanning without Wi-Fi connectivity.
-* The Wi-Fi scan type can be selected with the ``SIDEWALK_NRF7X_LOCATION_SCAN_TYPE`` Kconfig choice:
+Wi-Fi scanning with the nRF70 Series has the following limitations:
 
-  * ``CONFIG_SIDEWALK_NRF7X_LOCATION_SCAN_ACTIVE`` (default) - Resolves access points faster, at the cost of higher power consumption.
-  * ``CONFIG_SIDEWALK_NRF7X_LOCATION_SCAN_PASSIVE`` - Lower power consumption, but slower access point discovery.
+* GNSS is not available, because the nRF70 Series does not include a GNSS receiver.
+  Only the Wi-Fi location level can be resolved.
+* The nRF70 Series and the LR1110 are mutually exclusive as scanning sources.
+  The nRF70 Series is therefore unavailable when the LR1110 is selected as the sub-GHz radio, which includes builds for the :ref:`nRF Sidewalk EB <nrf_sidewalk_eb>`.
+
+The companion IC runs in the scan-only mode of the nRF70 driver (the ``CONFIG_NRF70_SCAN_ONLY`` Kconfig option, enabled by default for this feature), so it provides Wi-Fi scanning only, without Wi-Fi connectivity.
+
+To select the Wi-Fi scan type, use the ``SIDEWALK_NRF7X_LOCATION_SCAN_TYPE`` Kconfig choice:
+
+* ``CONFIG_SIDEWALK_NRF7X_LOCATION_SCAN_ACTIVE`` -- Default option.
+  Discovers access points faster, at the cost of higher power consumption.
+* ``CONFIG_SIDEWALK_NRF7X_LOCATION_SCAN_PASSIVE`` -- Discovers access points more slowly, but with lower power consumption.
 
 Testing
 *******
@@ -139,7 +145,7 @@ Location service is supported in Sidewalk libraries in the following range:
 * Sidewalk Sub-GHz library (LoRa and FSK) supports all location methods.
   However to build with radio and pal componets for WiFi and GNSS scanning, ``CONFIG_SIDEWALK_SUBGHZ_RADIO_LR1110`` must be enabled.
   This config is enabled automatically when sample is build with ``semtech_lr11xxmb1xxs`` shield.
-  Alternatively, the Wi-Fi scanning alone can be provided by an nRF70 Series companion IC, as described in :ref:`location_services_nrf70`.
+  Alternatively, the Wi-Fi scanning alone can be provided by an nRF70 Series companion IC, as described in :ref:`location_services_wifi_nrf70`.
 
 * Sidewalk Bluetooth LE only library supports the network location method over Bluetooth LE, and the Wi-Fi location method when an nRF70 Series companion IC is used.
 

--- a/doc/releases_and_migration/release_notes_addon_v130.rst
+++ b/doc/releases_and_migration/release_notes_addon_v130.rst
@@ -28,6 +28,9 @@ Changelog
 
   * Support for the :ref:`nRF Sidewalk EB <nrf_sidewalk_eb>` shield on the nRF54L15 DK and nRF54LM20 DK.
     The shield enables the LoRa and FSK link types.
+  * Support for the `nRF7002 EB II`_ shield on the nRF54L15 DK and nRF54LM20 DK.
+    The shield provides Wi-Fi location scanning with an nRF70 Series companion IC as an alternative to the LR1110 radio.
+    For details, see the :ref:`location_services` page.
   * :ref:`lr11xx_firmware_update` sample for updating Semtech LR1110 transceiver firmware.
   * :ref:`application_development` documentation section.
   * ``west sid provision`` command for generating the ``mfg_storage`` partition contents and flashing it to a connected board.

--- a/doc/samples/samples_list.rst
+++ b/doc/samples/samples_list.rst
@@ -59,6 +59,7 @@ The following table summarizes the supported variants, development kits, and bui
      - * External flash (included in the DK) on `nRF52840 DK`_ and nRF54L10 emulated on `nRF54L15 DK`_
        * `Semtech SX1262MB2CAS`_ or LR1110MB1xxS (LoRa/FSK only)
        * :ref:`nRF Sidewalk EB <nrf_sidewalk_eb>` on `nRF54LM20 DK`_ (LoRa/FSK)
+       * `nRF7002 EB II`_ on `nRF54L15 DK`_ and `nRF54LM20 DK`_ (Wi-Fi location)
      - MCUboot — DFU partition in external flash on `nRF52840 DK`_ and nRF54L10 emulated on `nRF54L15 DK`_
      - ``overlay-dut.conf``
 

--- a/doc/samples/sid_end_device.rst
+++ b/doc/samples/sid_end_device.rst
@@ -66,6 +66,50 @@ The supported modules are as follows:
    To use sub-GHz radio, the Semtech shield must be connected to the development kit header, and the antenna must be connected to the radio module.
    For the exact pin assignment, refer to the :ref:`setting_up_hardware_semtech_pinout` section.
 
+.. _sid_end_device_wifi_location_hw:
+
+Wi-Fi location hardware
+=======================
+
+To use Wi-Fi-based location scanning without the LR1110 radio, you can attach the `nRF7002 EB II`_ shield, which hosts an nRF70 Series Wi-Fi companion IC.
+The shield is supported on the nRF54L15 DK and the nRF54LM20 DK.
+The following shield variants are supported:
+
+* ``nrf7002eb2`` -- Uses the `nRF7002 <nRF7002 Product Page_>`_ IC.
+* ``nrf7002eb2_nrf7001`` -- Uses the `nRF7001 <nRF7001 Product Page_>`_ IC.
+* ``nrf7002eb2_nrf7000`` -- Uses the `nRF7000 <nRF7000 Product Page_>`_ IC.
+* ``nrf7002eb2_coex`` -- Adds the short-range radio coexistence pins.
+  This variant only extends one of the preceding variants, so you must provide both shields when building.
+
+Add the selected shield variant with the ``--shield`` option when building the sample, for example:
+
+.. code-block:: console
+
+   $ west build -b nrf54l15dk/nrf54l15/cpuapp --shield nrf7002eb2
+
+To add the coexistence pins, pass both shields as a semicolon-separated list:
+
+.. code-block:: console
+
+   $ west build -b nrf54l15dk/nrf54l15/cpuapp --shield "nrf7002eb2;nrf7002eb2_coex"
+
+.. note::
+   The nRF70 Series driver requires Wi-Fi firmware binary blobs that are not distributed with the repository, and are not fetched by the ``west update`` command.
+   Run the ``west blobs fetch nrf_wifi`` command before the first build, and repeat it after every update of the nRF Connect SDK.
+
+The nRF70 Series companion IC runs in the scan-only mode of the nRF70 driver (``CONFIG_NRF70_SCAN_ONLY``, enabled by default for this feature), so it provides Wi-Fi scanning for location purposes only, and no Wi-Fi connectivity.
+Enabling the Wi-Fi driver also increases the RAM and flash requirements of the application.
+
+For more information about how Wi-Fi location works, see :ref:`location_services`.
+
+The shield introduces the following limitations:
+
+* On both development kits, the shield conflicts with the second virtual serial port (VCOM1) on the UART20 pins, so the shield overlay disables UART20 and moves the console, shell, MCUmgr, and Bluetooth monitor to UART30.
+  Use the first virtual serial port (VCOM0) when you run the sample, and disable VCOM1 in the `Board Configurator`_ application.
+* On the nRF54L15 DK, **LED 1** shares a pin with the shield SPI chip select, and is unavailable while the shield is connected.
+  The ``state-notifier-time-sync`` alias is removed in such a build, so LED 1 no longer indicates the time synchronization state.
+* On the nRF54LM20 DK, **Button 3** shares a pin with the shield, and is unavailable while the shield is connected.
+
 Overview
 ********
 

--- a/doc/samples/sid_end_device.rst
+++ b/doc/samples/sid_end_device.rst
@@ -73,13 +73,29 @@ Wi-Fi location hardware
 
 To use Wi-Fi-based location scanning without the LR1110 radio, you can attach the `nRF7002 EB II`_ shield, which hosts an nRF70 Series Wi-Fi companion IC.
 The shield is supported on the nRF54L15 DK and the nRF54LM20 DK.
+
+The companion IC runs in the scan-only mode of the nRF70 driver (``CONFIG_NRF70_SCAN_ONLY``, enabled by default for this feature).
+This means that the IC provides Wi-Fi scanning for location purposes only, without Wi-Fi connectivity.
+Enabling the Wi-Fi driver also increases the RAM and flash requirements of the application.
+For more information about how Wi-Fi location works, see :ref:`location_services`.
+
+Supported shield variants
+-------------------------
+
 The following shield variants are supported:
 
 * ``nrf7002eb2`` -- Uses the `nRF7002 <nRF7002 Product Page_>`_ IC.
 * ``nrf7002eb2_nrf7001`` -- Uses the `nRF7001 <nRF7001 Product Page_>`_ IC.
 * ``nrf7002eb2_nrf7000`` -- Uses the `nRF7000 <nRF7000 Product Page_>`_ IC.
 * ``nrf7002eb2_coex`` -- Adds the short-range radio coexistence pins.
-  This variant only extends one of the preceding variants, so you must provide both shields when building.
+  This variant extends one of the preceding variants instead of replacing them, so you must always build with two shields: a base variant and ``nrf7002eb2_coex``.
+
+Building with the shield
+------------------------
+
+.. note::
+   The nRF70 Series driver requires Wi-Fi firmware binary blobs that are not distributed with the repository, and are not fetched by the ``west update`` command.
+   Run the ``west blobs fetch nrf_wifi`` command before the first build, and repeat it after every update of the nRF Connect SDK.
 
 Add the selected shield variant with the ``--shield`` option when building the sample, for example:
 
@@ -93,16 +109,10 @@ To add the coexistence pins, pass both shields as a semicolon-separated list:
 
    $ west build -b nrf54l15dk/nrf54l15/cpuapp --shield "nrf7002eb2;nrf7002eb2_coex"
 
-.. note::
-   The nRF70 Series driver requires Wi-Fi firmware binary blobs that are not distributed with the repository, and are not fetched by the ``west update`` command.
-   Run the ``west blobs fetch nrf_wifi`` command before the first build, and repeat it after every update of the nRF Connect SDK.
+Limitations
+-----------
 
-The nRF70 Series companion IC runs in the scan-only mode of the nRF70 driver (``CONFIG_NRF70_SCAN_ONLY``, enabled by default for this feature), so it provides Wi-Fi scanning for location purposes only, and no Wi-Fi connectivity.
-Enabling the Wi-Fi driver also increases the RAM and flash requirements of the application.
-
-For more information about how Wi-Fi location works, see :ref:`location_services`.
-
-The shield introduces the following limitations:
+The shield has the following limitations:
 
 * On both development kits, the shield conflicts with the second virtual serial port (VCOM1) on the UART20 pins, so the shield overlay disables UART20 and moves the console, shell, MCUmgr, and Bluetooth monitor to UART30.
   Use the first virtual serial port (VCOM0) when you run the sample, and disable VCOM1 in the `Board Configurator`_ application.

--- a/doc/samples/variants/dut.rst
+++ b/doc/samples/variants/dut.rst
@@ -173,7 +173,8 @@ Testing Location Services
          <inf> location_shell_events: loc link type: 1
          <inf> location_shell_events: location_event_send mode: 1, returned 0
 
-   #. For Wi-Fi and GNSS location, ensure that the required LR1110 radio hardware is connected.
+   #. For GNSS location, ensure that the LR1110 radio hardware is connected.
+      For Wi-Fi location, use either the LR1110 radio or an nRF70 Series Wi-Fi companion IC, as described in :ref:`location_services`.
 
       .. note::
 


### PR DESCRIPTION
Describe the nRF70 Series Wi-Fi companion IC as an alternative to the LR1110-based Wi-Fi scan for the Sidewalk location services.

Document the supported nRF7002 EB II shield variants, the required Wi-Fi firmware blobs and the nRF54L15 DK limitations in the Sidewalk end device sample, update the hardware requirements of the location methods and add a release note entry for the shield support.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
