### PR TITLE
subsys: lr11xx: stop LBM from sleeping a radio it does not own

### DIFF
--- a/subsys/semtech/lr11xx/lr11xx_radio.c
+++ b/subsys/semtech/lr11xx/lr11xx_radio.c
@@ -804,7 +804,11 @@ int32_t sid_pal_radio_sleep( uint32_t sleep_us )
             set_radio_int( &drv_ctx, false );
         }
 
-        if( lr11xx_system_set_sleep( &drv_ctx, cfg, INFINITE_TIME ) != LR11XX_STATUS_OK )
+        lr11xx_system_sleep_request_begin( );
+        const lr11xx_status_t sleep_status = lr11xx_system_set_sleep( &drv_ctx, cfg, INFINITE_TIME );
+        lr11xx_system_sleep_request_end( );
+
+        if( sleep_status != LR11XX_STATUS_OK )
         {
             err = RADIO_ERROR_HARDWARE_ERROR;
             if( drv_ctx.config->mitigations.irq_noise_during_sleep )
@@ -1823,6 +1827,8 @@ void lr11xx_restore_transceiver()
 volatile uint8_t testcnt;
 #endif /* CONFIG_RADIO_LOCK_TEST */
 
+static uint8_t state_before_scan = SID_PAL_RADIO_UNKNOWN;
+
 int sid_pal_radio_hold_scan()
 {
 	uint8_t pinState;
@@ -1851,6 +1857,7 @@ int sid_pal_radio_hold_scan()
      SL_SID_LOG_APP_WARNING(BYEL "hold scan: radio in use"COLOR_RESET);
      return -1;
   }
+  state_before_scan = drv_ctx.radio_state;
   drv_ctx.radio_state = SID_PAL_RADIO_SCAN;
   sid_pal_exit_critical_region();
 #ifdef CONFIG_RADIO_LOCK_TEST
@@ -1887,6 +1894,18 @@ void sid_pal_radio_release_scan()
 	SL_SID_LOG_APP_INFO("sid_pal_release");
 #endif /* CONFIG_RADIO_LOCK_TEST */
 	sid_pal_exit_critical_region();
+
+	/* The LBM radio planner sleeps the chip when its task ends, but those requests are
+	 * rejected once Sidewalk owns the radio again. Park the chip in the state it was in
+	 * before the scan. */
+	if (state_before_scan == SID_PAL_RADIO_SLEEP) {
+		int32_t err = sid_pal_radio_sleep(0);
+
+		if (err != RADIO_ERROR_NONE) {
+			SL_SID_LOG_APP_ERROR("%ld = release scan sleep", err);
+		}
+	}
+	state_before_scan = SID_PAL_RADIO_UNKNOWN;
 }
 
 void sid_pal_radio_gnss_prescan()

--- a/subsys/semtech/lr11xx/semtech/lr11xx_system.c
+++ b/subsys/semtech/lr11xx/semtech/lr11xx_system.c
@@ -41,6 +41,20 @@
 
 #include "lr11xx_system.h"
 #include "lr11xx_hal.h"
+#include "halo_lr11xx_radio.h"
+#include "sl_sidewalk_log_app.h"
+
+static bool sid_sleep_request;
+
+void lr11xx_system_sleep_request_begin( void )
+{
+    sid_sleep_request = true;
+}
+
+void lr11xx_system_sleep_request_end( void )
+{
+    sid_sleep_request = false;
+}
 
 /*
  * -----------------------------------------------------------------------------
@@ -439,6 +453,28 @@ lr11xx_status_t lr11xx_system_set_sleep( const void* context, const lr11xx_syste
         ( uint8_t ) ( sleep_time >> 8 ),
         ( uint8_t ) ( sleep_time >> 0 ),
     };
+
+    if( !sid_sleep_request )
+    {
+        const halo_drv_semtech_ctx_t* drv_ctx = lr11xx_get_drv_ctx( );
+
+        if( drv_ctx != NULL && drv_ctx->radio_state != SID_PAL_RADIO_SCAN )
+        {
+            if( drv_ctx->radio_state != SID_PAL_RADIO_SLEEP )
+            {
+                /* Dropping the request leaves the chip somewhere other than sleep.
+                 * Either sid_pal_radio_release_scan() failed to park it, or LBM is
+                 * driving the radio while Sidewalk is actively using it. */
+                SL_SID_LOG_APP_ERROR( "drop LBM set_sleep, radio not parked, state %u",
+                                      drv_ctx->radio_state );
+            }
+            /* Report success even though nothing is sent to the chip: the LBM radio
+             * planner wraps ral_set_sleep() in a panic-on-failure check
+             * (rp_callback in radio_planner.c), so any other return value kills
+             * the modem. */
+            return LR11XX_STATUS_OK;
+        }
+    }
 
     return ( lr11xx_status_t ) lr11xx_hal_write( context, cbuffer, LR11XX_SYSTEM_SET_SLEEP_CMD_LENGTH, 0, 0 );
 }

--- a/subsys/semtech/lr11xx/semtech/lr11xx_system.h
+++ b/subsys/semtech/lr11xx/semtech/lr11xx_system.h
@@ -415,6 +415,18 @@ lr11xx_status_t lr11xx_system_set_sleep( const void* context, const lr11xx_syste
                                          const uint32_t sleep_time );
 
 /*!
+ * @brief Mark the following lr11xx_system_set_sleep() call as originating from the
+ * Sidewalk stack. Requests that arrive without this marker while the radio is not in
+ * scan mode come from the LBM radio planner and are dropped.
+ */
+void lr11xx_system_sleep_request_begin( void );
+
+/*!
+ * @brief End the window opened by lr11xx_system_sleep_request_begin().
+ */
+void lr11xx_system_sleep_request_end( void );
+
+/*!
  * @brief Set the device into the requested Standby mode
  *
  * @param [in] context Chip implementation context


### PR DESCRIPTION
The LBM radio planner (ral_lr11xx_set_sleep) and the Sidewalk stack (sid_pal_radio_sleep) both reach lr11xx_system_set_sleep. LBM only owns the chip between sid_pal_radio_hold_scan() and sid_pal_radio_release_scan(), that is while radio_state is SID_PAL_RADIO_SCAN. Outside that window it kept issuing SetSleep, putting the chip into deep sleep behind the Sidewalk driver's back.

The driver then still had drv_ctx.sleeping cleared, so the next command went out without the NSS wake-up pulse and stalled on BUSY for 40 ms. The chip also rejected the stray SetSleep with a parameter error, raised IRQ_CMD_ERROR and held INT1 high, which made sid_pal_radio_irq_process() spin. After every Wi-Fi scan this burned roughly seven seconds before the radio planner gave up.

Drop sleep requests that do not originate from sid_pal_radio_sleep() while the radio is not in scan mode. Such a request is reported as successful, because the radio planner wraps ral_set_sleep() in a panic-on-failure check and any other return value kills the modem. Log an error if the radio is not already parked in sleep at that point, since that would mean the chip is left drawing idle current.

Restore the pre-scan radio state in sid_pal_radio_release_scan() so the chip goes back to sleep once Sidewalk takes it over again. Without this it stayed in STBY_RC and drew an extra 1.66 mA.

## CI parameters

```yaml
Jenkins:
  test-sdk-sidewalk: master
  # To reconfigure functional tests:
  # use GH labels func-* (default is func-commit)
  # or
  # Use YAML Filters. Helper side to set filters: https://tester-pc.nordicsemi.no:8080/test_mgmt
  # Filters (place copied YAML filters here):
  #  - filter1:
  #     board: nrf54l
```

## Description

JIRA ticket: 

## Self review

- [ ] There is no commented code.
- [ ] There are no TODO/FIXME comments without associated issue ticket.
- [ ] Commits are properly organized.
- [ ] Change has been tested.
- [ ] Tests were updated (if applicable).
